### PR TITLE
Ignore IntelliJ root configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,10 +77,7 @@ local.properties
 ######################
 # Intellij
 ######################
-**/.idea/*
-!.idea/codeStyleSettings.xml
-!.idea/codeStyles
-!.idea/runConfigurations
+.idea/
 *.iml
 *.iws
 *.ipr


### PR DESCRIPTION
Patterns such as `**/.idea/*` do not match for directory at root.

Morevover, preserved configuration files at root are not commited for now.