### PR TITLE
Fix Finally Action target mapping error

### DIFF
--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapper.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapper.java
@@ -3,12 +3,13 @@ package com.chutneytesting.engine.domain.execution.engine;
 import static com.chutneytesting.engine.domain.environment.NoTarget.NO_TARGET;
 import static com.chutneytesting.engine.domain.environment.SecurityInfo.Credential;
 
+import java.util.Optional;
+
 import com.chutneytesting.engine.domain.environment.ImmutableTarget;
 import com.chutneytesting.engine.domain.environment.SecurityInfo;
 import com.chutneytesting.engine.domain.environment.Target;
 import com.chutneytesting.engine.domain.execution.StepDefinition;
 import com.chutneytesting.task.spi.FinallyAction;
-import java.util.Optional;
 
 class FinallyActionMapper {
 
@@ -48,6 +49,6 @@ class FinallyActionMapper {
 
     private Credential mapCreds(Optional<com.chutneytesting.task.spi.injectable.SecurityInfo.Credential> credential) {
         return credential.map(c -> Credential.of(c.username(), c.password()))
-            .orElse(Credential.of("", ""));
+            .orElse(null);
     }
 }

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapperTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapperTest.java
@@ -1,0 +1,41 @@
+package com.chutneytesting.engine.domain.execution.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import org.junit.Test;
+
+import com.chutneytesting.engine.domain.environment.ImmutableTarget;
+import com.chutneytesting.engine.domain.execution.StepDefinition;
+import com.chutneytesting.engine.domain.execution.engine.parameterResolver.TargetSpiImpl;
+import com.chutneytesting.task.spi.FinallyAction;
+import com.chutneytesting.task.spi.injectable.Target;
+
+public class FinallyActionMapperTest {
+
+    private final FinallyActionMapper mapper = new FinallyActionMapper();
+
+    @Test
+    public void upright_finally_action_copy() {
+        ImmutableTarget domainTarget = ImmutableTarget.builder()
+            .id(com.chutneytesting.engine.domain.environment.Target.TargetId.of("test-target"))
+            .url("proto://host:12345")
+            .build();
+        Target taskTarget = new TargetSpiImpl(domainTarget);
+        FinallyAction finallyAction = FinallyAction.Builder
+            .forAction("test-action")
+            .withTarget(taskTarget)
+            .withInput("test-input", "test")
+            .build();
+
+        StepDefinition stepDefinition = mapper.toStepDefinition(finallyAction);
+
+        assertThat(stepDefinition.type).isEqualTo("test-action");
+        assertThat(stepDefinition.inputs).containsOnly(entry("test-input", "test"));
+        assertThat(stepDefinition.getTarget()).isPresent();
+        com.chutneytesting.engine.domain.environment.Target targetCopy = stepDefinition.getTarget().get();
+        assertThat(targetCopy.name()).isEqualTo("test-target");
+        assertThat(targetCopy.url()).isEqualTo("proto://host:12345");
+        assertThat(targetCopy.security().credential()).isEmpty();
+    }
+}


### PR DESCRIPTION
Finally action mapping should reflect the given configuration and not
substitute no credentials by empty ones.