### PR TITLE
bugfix(ui): Correctly order scenarios by last execution when one is not executed

### DIFF
--- a/ui/src/app/modules/campaign/components/execution/execution-campaign.component.html
+++ b/ui/src/app/modules/campaign/components/execution/execution-campaign.component.html
@@ -138,20 +138,20 @@
                 <thead>
                     <tr>
                         <th scope="col" class="filter w5" (click)="sortCurrentBy('scenarioId')">{{ 'campaigns.execution.scenarios.item.header.id' | translate }}
-                            <span *ngIf="orderBy == 'scenarioId' && !reverseOrder" class="fa fa-caret-down"></span>
-                            <span *ngIf="orderBy == 'scenarioId' && reverseOrder" class="fa fa-caret-up"></span>
+                            <span *ngIf="orderBy == 'scenarioId' && reverseOrder" class="fa fa-caret-down"></span>
+                            <span *ngIf="orderBy == 'scenarioId' && !reverseOrder" class="fa fa-caret-up"></span>
                         </th>
                         <th scope="col" class="filter w5" (click)="sortCurrentBy('status')">{{ 'campaigns.execution.scenarios.item.header.state' | translate }}
-                            <span *ngIf="orderBy == 'status' && !reverseOrder" class="fa fa-caret-down"></span>
-                            <span *ngIf="orderBy == 'status' && reverseOrder" class="fa fa-caret-up"></span>
+                            <span *ngIf="orderBy == 'status' && reverseOrder" class="fa fa-caret-down"></span>
+                            <span *ngIf="orderBy == 'status' && !reverseOrder" class="fa fa-caret-up"></span>
                         </th>
                         <th scope="col" class="filter w80" (click)="sortCurrentBy('scenarioName')">{{ 'campaigns.execution.scenarios.item.header.title' | translate }}
-                            <span *ngIf="orderBy == 'scenarioName' && !reverseOrder" class="fa fa-caret-down"></span>
-                            <span *ngIf="orderBy == 'scenarioName' && reverseOrder" class="fa fa-caret-up"></span>
+                            <span *ngIf="orderBy == 'scenarioName' && reverseOrder" class="fa fa-caret-down"></span>
+                            <span *ngIf="orderBy == 'scenarioName' && !reverseOrder" class="fa fa-caret-up"></span>
                         </th>
                         <th scope="col" class="filter w10" (click)="sortCurrentBy('duration')">{{ 'campaigns.execution.scenarios.item.header.duration' | translate }}
-                            <span *ngIf="orderBy == 'duration' && !reverseOrder" class="fa fa-caret-down"></span>
-                            <span *ngIf="orderBy == 'duration' && reverseOrder" class="fa fa-caret-up"></span>
+                            <span *ngIf="orderBy == 'duration' && reverseOrder" class="fa fa-caret-down"></span>
+                            <span *ngIf="orderBy == 'duration' && !reverseOrder" class="fa fa-caret-up"></span>
                         </th>
                     </tr>
                 </thead>
@@ -187,16 +187,16 @@
                 <tr>
                     <th scope="col" class="w1">&nbsp;</th>
                     <th scope="col" class="filter w70" (click)="sortLastBy('title')">{{ 'campaigns.execution.scenarios.header.title' | translate }}
-                        <span *ngIf="orderBy == 'title' && !reverseOrder" class="fa fa-caret-down"></span>
-                        <span *ngIf="orderBy == 'title' && reverseOrder" class="fa fa-caret-up"></span>
+                        <span *ngIf="orderBy == 'title' && reverseOrder" class="fa fa-caret-down"></span>
+                        <span *ngIf="orderBy == 'title' && !reverseOrder" class="fa fa-caret-up"></span>
                     </th>
                     <th scope="col" class="filter w15" (click)="sortLastBy('tags')">{{ 'campaigns.execution.scenarios.header.tags' | translate }}
-                        <span *ngIf="orderBy == 'tags' && !reverseOrder" class="fa fa-caret-down"></span>
-                        <span *ngIf="orderBy == 'tags' && reverseOrder" class="fa fa-caret-up"></span>
+                        <span *ngIf="orderBy == 'tags' && reverseOrder" class="fa fa-caret-down"></span>
+                        <span *ngIf="orderBy == 'tags' && !reverseOrder" class="fa fa-caret-up"></span>
                     </th>
                     <th scope="col" class="filter w14" (click)="sortLastBy('creationDate')">{{ 'campaigns.execution.scenarios.header.creation' | translate }}
-                        <span *ngIf="orderBy == 'creationDate' && !reverseOrder" class="fa fa-caret-down"></span>
-                        <span *ngIf="orderBy == 'creationDate' && reverseOrder" class="fa fa-caret-up"></span>
+                        <span *ngIf="orderBy == 'creationDate' && reverseOrder" class="fa fa-caret-down"></span>
+                        <span *ngIf="orderBy == 'creationDate' && !reverseOrder" class="fa fa-caret-up"></span>
                     </th>
                 </tr>
                 </thead>
@@ -229,7 +229,7 @@
         </div>
     </div>
     <div *ngIf="!currentCampaignExecutionReport && lineChartData.length > 0" class="col-md-3">
-        <canvas baseChart 
+        <canvas baseChart
         [datasets]="lineChartData"
         [labels]="lineChartLabels"
         [options]="lineChartOptions"

--- a/ui/src/app/modules/campaign/components/execution/execution-campaign.component.ts
+++ b/ui/src/app/modules/campaign/components/execution/execution-campaign.component.ts
@@ -189,9 +189,22 @@ export class CampaignExecutionComponent implements OnInit, OnDestroy {
 
         return sortByAndOrder(
             collection,
-            (i) => i[this.orderBy],
+            this.getKeyExtractorBy(property),
             this.reverseOrder
         );
+    }
+
+    private getKeyExtractorBy(property: string) {
+        if (property == 'title') {
+            return i => i[property] == null ? '' : i[property].toLowerCase();
+        }
+        if (property == 'creationDate') {
+            const now = Date.now();
+            return i => i[property] == null ? now - 1491841324 /*2017-04-10T16:22:04*/ : now - Date.parse(i[property]);
+        }
+        else {
+            return i => i[property] == null ? '' : i[property];
+        }
     }
 
     executeCampaign(env: string) {

--- a/ui/src/app/modules/scenarios/components/search-list/scenarios.component.html
+++ b/ui/src/app/modules/scenarios/components/search-list/scenarios.component.html
@@ -91,34 +91,34 @@
             <thead>
             <tr>
                 <th class="filter w3" scope="col" (click)="sortBy('id')">ID
-                    <span *ngIf="orderBy == 'id' && !reverseOrder" class="fa fa-caret-down"></span>
-                    <span *ngIf="orderBy == 'id' && reverseOrder" class="fa fa-caret-up"></span>
+                    <span *ngIf="orderBy == 'id' && reverseOrder" class="fa fa-caret-down"></span>
+                    <span *ngIf="orderBy == 'id' && !reverseOrder" class="fa fa-caret-up"></span>
                 </th>
                 <th scope="col" class="w1">&nbsp;</th>
                 <th class="filter w3" scope="col" (click)="sortBy('status')">{{ 'scenarios.list.header.status'  | translate  }}
-                    <span *ngIf="orderBy == 'status' && !reverseOrder" class="fa fa-caret-down"></span>
-                    <span *ngIf="orderBy == 'status' && reverseOrder" class="fa fa-caret-up"></span>
+                    <span *ngIf="orderBy == 'status' && reverseOrder" class="fa fa-caret-down"></span>
+                    <span *ngIf="orderBy == 'status' && !reverseOrder" class="fa fa-caret-up"></span>
                 </th>
                 <th class="filter w10" scope="col" (click)="sortBy('lastExecution')">{{ 'scenarios.list.header.execLast'  | translate  }}
-                    <span *ngIf="orderBy == 'lastExecution' && !reverseOrder" class="fa fa-caret-down"></span>
-                    <span *ngIf="orderBy == 'lastExecution' && reverseOrder" class="fa fa-caret-up"></span>
+                    <span *ngIf="orderBy == 'lastExecution' && reverseOrder" class="fa fa-caret-down"></span>
+                    <span *ngIf="orderBy == 'lastExecution' && !reverseOrder" class="fa fa-caret-up"></span>
                 </th>
                 <th class="filter w5" scope="col" (click)="sortBy('executionCount')">{{ 'scenarios.list.header.execCount'  | translate  }}
-                    <span *ngIf="orderBy == 'executionCount' && !reverseOrder" class="fa fa-caret-down"></span>
-                    <span *ngIf="orderBy == 'executionCount' && reverseOrder" class="fa fa-caret-up"></span>
+                    <span *ngIf="orderBy == 'executionCount' && reverseOrder" class="fa fa-caret-down"></span>
+                    <span *ngIf="orderBy == 'executionCount' && !reverseOrder" class="fa fa-caret-up"></span>
                 </th>
                 <th class="filter w50" scope="col" (click)="sortBy('title')">{{ 'scenarios.list.header.title'  | translate  }}
-                    <span *ngIf="orderBy == 'title' && !reverseOrder" class="fa fa-caret-down"></span>
-                    <span *ngIf="orderBy == 'title' && reverseOrder" class="fa fa-caret-up"></span>
+                    <span *ngIf="orderBy == 'title' && reverseOrder" class="fa fa-caret-down"></span>
+                    <span *ngIf="orderBy == 'title' && !reverseOrder" class="fa fa-caret-up"></span>
                 </th>
                 <th scope="col" class="w1">&nbsp;</th>
                 <th class="filter w12" scope="col" (click)="sortBy('tags')">{{ 'scenarios.list.header.tags'  | translate  }}
-                    <span *ngIf="orderBy == 'tags' && !reverseOrder" class="fa fa-caret-down"></span>
-                    <span *ngIf="orderBy == 'tags' && reverseOrder" class="fa fa-caret-up"></span>
+                    <span *ngIf="orderBy == 'tags' && reverseOrder" class="fa fa-caret-down"></span>
+                    <span *ngIf="orderBy == 'tags' && !reverseOrder" class="fa fa-caret-up"></span>
                 </th>
                 <th class="filter w10" scope="col" (click)="sortBy('creationDate')">{{ 'scenarios.list.header.creation'  | translate  }}
-                    <span *ngIf="orderBy == 'creationDate' && !reverseOrder" class="fa fa-caret-down"></span>
-                    <span *ngIf="orderBy == 'creationDate' && reverseOrder" class="fa fa-caret-up"></span>
+                    <span *ngIf="orderBy == 'creationDate' && reverseOrder" class="fa fa-caret-down"></span>
+                    <span *ngIf="orderBy == 'creationDate' && !reverseOrder" class="fa fa-caret-up"></span>
                 </th>
             </tr>
             </thead>

--- a/ui/src/app/modules/scenarios/components/search-list/scenarios.component.ts
+++ b/ui/src/app/modules/scenarios/components/search-list/scenarios.component.ts
@@ -141,7 +141,11 @@ export class ScenariosComponent implements OnInit, OnDestroy {
     }
 
     sortScenarios(property, reverseOrder) {
-        this.viewedScenarios = sortByAndOrder(this.viewedScenarios, i => i[property], reverseOrder);
+        this.viewedScenarios = sortByAndOrder(
+            this.viewedScenarios,
+            i => i[property] == null ? '' : i[property],
+            reverseOrder
+        );
     }
 
     // Filtering //

--- a/ui/src/app/modules/scenarios/components/search-list/scenarios.component.ts
+++ b/ui/src/app/modules/scenarios/components/search-list/scenarios.component.ts
@@ -143,9 +143,18 @@ export class ScenariosComponent implements OnInit, OnDestroy {
     sortScenarios(property, reverseOrder) {
         this.viewedScenarios = sortByAndOrder(
             this.viewedScenarios,
-            i => i[property] == null ? '' : i[property],
-            reverseOrder
+            this.getKeyExtractorBy(property),
+            property == 'title' ? !reverseOrder : reverseOrder
         );
+    }
+
+    private getKeyExtractorBy(property: string) {
+        if (property == 'title') {
+            return i => i[property] == null ? '' : i[property].toLowerCase();
+        }
+        else {
+            return i => i[property] == null ? '' : i[property];
+        }
     }
 
     // Filtering //
@@ -240,5 +249,4 @@ export class ScenariosComponent implements OnInit, OnDestroy {
             }
         });
     }
-
 }

--- a/ui/src/app/modules/scenarios/components/search-list/scenarios.component.ts
+++ b/ui/src/app/modules/scenarios/components/search-list/scenarios.component.ts
@@ -144,13 +144,17 @@ export class ScenariosComponent implements OnInit, OnDestroy {
         this.viewedScenarios = sortByAndOrder(
             this.viewedScenarios,
             this.getKeyExtractorBy(property),
-            property == 'title' ? !reverseOrder : reverseOrder
+            reverseOrder
         );
     }
 
     private getKeyExtractorBy(property: string) {
         if (property == 'title') {
             return i => i[property] == null ? '' : i[property].toLowerCase();
+        }
+        if (property == 'lastExecution' || property == 'creationDate') {
+            const now = Date.now();
+            return i => i[property] == null ? now - 1491841324 /*2017-04-10T16:22:04*/ : now - Date.parse(i[property]);
         }
         else {
             return i => i[property] == null ? '' : i[property];


### PR DESCRIPTION
FIX #149 