### PR TITLE
feat(task-impl): Allow bad content type in message received

### DIFF
--- a/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTask.java
@@ -203,16 +203,21 @@ public class KafkaBasicConsumeTask implements Task {
     }
 
     private void checkContentTypeHeader(Map<String, Object> headers) {
-        Optional<MimeType> contentType = headers.entrySet().stream()
-            .filter(e -> e.getKey().replaceAll("[- ]", "").equalsIgnoreCase("contenttype"))
-            .findAny()
-            .map(Map.Entry::getValue)
-            .map(Object::toString)
-            .map(MimeTypeUtils::parseMimeType);
+        try {
+            Optional<MimeType> contentType = headers.entrySet().stream()
+                .filter(e -> e.getKey().replaceAll("[- ]", "").equalsIgnoreCase("contenttype"))
+                .findAny()
+                .map(Map.Entry::getValue)
+                .map(Object::toString)
+                .map(s -> s.replace("\"", ""))
+                .map(MimeTypeUtils::parseMimeType);
 
-        contentType.ifPresent(ct -> {
-            logger.info("Found content type header " + ct);
-            this.contentType = ct;
-        });
+            contentType.ifPresent(ct -> {
+                logger.info("Found content type header " + ct);
+                this.contentType = ct;
+            });
+        } catch (Exception e) {
+            logger.error("Cannot retrieve content type from message received:  " + e.getMessage());
+        }
     }
 }

--- a/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTaskTest.java
@@ -276,6 +276,29 @@ public class KafkaBasicConsumeTaskTest {
         assertThat(logger.errors).isNotEmpty();
     }
 
+    @Test
+    @Parameters({"bad content type", APPLICATION_JSON_VALUE, "\"" + APPLICATION_JSON_VALUE + "\""})
+    public void should_consume_as_json_with_bad_content_type_in_received_message(String contentType) {
+        ImmutableList<Header> headers = ImmutableList.of(
+            new RecordHeader("Content-type", contentType.getBytes())
+        );
+        // Given
+        Task task = givenKafkaConsumeTask(null, null, null);
+        givenTaskReceiveMessages(task,
+            buildRecord(FIRST_OFFSET, "KEY", "{\"value\": \"test message\", \"id\": \"1111\" }", headers)
+        );
+
+        // When
+        TaskExecutionResult taskExecutionResult = task.execute();
+
+        // Then
+        assertThat(taskExecutionResult.status).isEqualTo(Success);
+
+        final Map<String, Object> payload = ((List<Map<String, Object>>) taskExecutionResult.outputs.get(OUTPUT_PAYLOADS)).get(0);
+        assertThat(payload.get("value")).isEqualTo("test message");
+        assertThat(payload.get("id")).isEqualTo("1111");
+    }
+
     private MessageListener<String, String> overrideTaskMessageListenerContainer(Task task) {
         ConsumerFactory<String, String> cf = mock(ConsumerFactory.class);
         Consumer<String, String> consumer = mock(Consumer.class);


### PR DESCRIPTION
Unwrapper string inspired by https://github.com/spring-cloud/spring-cloud-stream/blob/master/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CompositeMessageConverterFactory.java