### PR TITLE
chore: Setup jdk11 config with nix

### DIFF
--- a/.env.nix
+++ b/.env.nix
@@ -1,16 +1,21 @@
-let
-  unstable = import (fetchTarball https://nixos.org/channels/nixos-unstable/nixexprs.tar.xz) { };
-in
 { nixpkgs ? import <nixpkgs> {} }:
-with nixpkgs; mkShell {
+with nixpkgs;
+let
+  jdk = openjdk11;
+  mvn = maven.override { jdk  = jdk; };
+in
+mkShell {
 
   buildInputs = [
-    unstable.nodejs-12_x
+    nodejs-12_x
     chromium
     geckodriver
+    jdk
+    mvn
   ];
 
   NPM_CONFIG_PROXY = builtins.getEnv "http_proxy";
   CHROME_BIN = "${chromium}/bin/chromium";
-
+  JAVA_HOME="${jdk}/lib/openjdk";
+  M2_HOME="${mvn}/maven";
 }

--- a/.envrc
+++ b/.envrc
@@ -19,6 +19,8 @@ use_nix .env.nix
 ## Symlink npm home
 ln -sfn $(dirname "$(dirname "$(readlink -f $(which npm))")") .env/npm_home && echo "Symlink npm home dir"
 
+## Symlink JDK
+ln -sfn $JAVA_HOME .env/jdk && echo "Symlink jdk \"$JAVA_HOME\""
 
 ## Mimicking frontend-maven-plugin ##
 


### PR DESCRIPTION
#### Describe the changes you've made

Using nix and direnv, entering the project directory will download jdk11, simlink it into .env folder for idea (or other) to point to it, and update maven to use jdk11.
