### PR TITLE
feat(task) : Prevent OOM on large SQL queries

### DIFF
--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultStepExecutorTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultStepExecutorTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 import com.chutneytesting.engine.domain.environment.TargetImpl;
 import com.chutneytesting.engine.domain.execution.engine.step.Step;
 import com.chutneytesting.engine.domain.execution.engine.step.StepContext;
-import com.chutneytesting.task.TestTaskTemplateFactory.ComplexeTask;
+import com.chutneytesting.task.TestTaskTemplateFactory.ComplexTask;
 import com.chutneytesting.task.domain.TaskTemplate;
 import com.chutneytesting.task.domain.TaskTemplateParserV2;
 import com.chutneytesting.task.domain.TaskTemplateRegistry;
@@ -59,7 +59,7 @@ public class DefaultStepExecutorTest {
     @Test
     public void should_execute_a_real_task() {
         TaskTemplateRegistry taskTemplateRegistry = mock(TaskTemplateRegistry.class);
-        TaskTemplate taskTemplate = new TaskTemplateParserV2().parse(ComplexeTask.class).result();
+        TaskTemplate taskTemplate = new TaskTemplateParserV2().parse(ComplexTask.class).result();
 
         when(taskTemplateRegistry.getByIdentifier(any())).thenReturn(Optional.of(taskTemplate));
 

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultStepExecutorTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultStepExecutorTest.java
@@ -12,6 +12,7 @@ import com.chutneytesting.engine.domain.environment.TargetImpl;
 import com.chutneytesting.engine.domain.execution.engine.step.Step;
 import com.chutneytesting.engine.domain.execution.engine.step.StepContext;
 import com.chutneytesting.task.TestTaskTemplateFactory.ComplexTask;
+import com.chutneytesting.task.TestTaskTemplateFactory.OomTask;
 import com.chutneytesting.task.domain.TaskTemplate;
 import com.chutneytesting.task.domain.TaskTemplateParserV2;
 import com.chutneytesting.task.domain.TaskTemplateRegistry;
@@ -69,6 +70,23 @@ public class DefaultStepExecutorTest {
         inputs.put("param1", "a");
         inputs.put("param2", "b");
         when(stepContext.getEvaluatedInputs()).thenReturn(inputs);
+
+        Step step = mock(Step.class, RETURNS_DEEP_STUBS);
+
+        StepExecutor stepExecutor = new DefaultStepExecutor(taskTemplateRegistry);
+        stepExecutor.execute(createScenarioExecution(), stepContext, mock(TargetImpl.class), step);
+
+        verify(step, times(0)).failure(any(Exception.class));
+    }
+
+    @Test
+    public void should_prevent_oom_exceptions() {
+        TaskTemplateRegistry taskTemplateRegistry = mock(TaskTemplateRegistry.class);
+        TaskTemplate taskTemplate = new TaskTemplateParserV2().parse(OomTask.class).result();
+
+        when(taskTemplateRegistry.getByIdentifier(any())).thenReturn(Optional.of(taskTemplate));
+
+        StepContext stepContext = mock(StepContext.class);
 
         Step step = mock(Step.class, RETURNS_DEEP_STUBS);
 

--- a/engine/src/test/java/com/chutneytesting/task/TestTaskTemplateFactory.java
+++ b/engine/src/test/java/com/chutneytesting/task/TestTaskTemplateFactory.java
@@ -83,12 +83,12 @@ public abstract class TestTaskTemplateFactory {
         }
     }
 
-    public static class ComplexeTask implements Task {
+    public static class ComplexTask implements Task {
 
         private final String someString;
         private final Pojo someObject;
 
-        public ComplexeTask(@Input("stringParam") String someString, @Input("pojoParam") Pojo someObject) {
+        public ComplexTask(@Input("stringParam") String someString, @Input("pojoParam") Pojo someObject) {
            this.someString = someString;
            this.someObject = someObject;
         }

--- a/engine/src/test/java/com/chutneytesting/task/TestTaskTemplateFactory.java
+++ b/engine/src/test/java/com/chutneytesting/task/TestTaskTemplateFactory.java
@@ -1,5 +1,8 @@
 package com.chutneytesting.task;
 
+import static com.chutneytesting.tools.ChutneyMemoryInfo.committedMemory;
+import static com.chutneytesting.tools.ChutneyMemoryInfo.usedMemory;
+
 import com.chutneytesting.task.domain.TaskInstantiationFailureException;
 import com.chutneytesting.task.domain.TaskTemplate;
 import com.chutneytesting.task.domain.UnresolvableTaskParameterException;
@@ -9,6 +12,8 @@ import com.chutneytesting.task.spi.Task;
 import com.chutneytesting.task.spi.TaskExecutionResult;
 import com.chutneytesting.task.spi.injectable.Input;
 import com.chutneytesting.task.spi.time.Duration;
+import com.chutneytesting.tools.ChutneyMemoryInfo;
+import com.chutneytesting.tools.NotEnoughMemoryException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -99,6 +104,32 @@ public abstract class TestTaskTemplateFactory {
             store.put("someString", someString);
             store.put("someObject", someObject);
             return TaskExecutionResult.ok(store);
+        }
+    }
+
+    public static class OomTask implements Task {
+
+        @Override
+        public TaskExecutionResult execute() {
+
+            int dummyArraySize = Integer.MAX_VALUE / 10;
+            Map<String, String> outputs = new HashMap<>(1);
+            try {
+                long[] memoryAllocated;
+                for (int i = 0; i < Integer.MAX_VALUE; i++) {
+                    if (!ChutneyMemoryInfo.hasEnoughAvailableMemory()) {
+                        throw new NotEnoughMemoryException(usedMemory(), committedMemory(), "custom message");
+                    }
+                    memoryAllocated = new long[dummyArraySize];
+                    memoryAllocated[0] = dummyArraySize;
+                    dummyArraySize += Integer.MAX_VALUE / 100;
+                }
+            } catch (NotEnoughMemoryException e) {
+                outputs.put("result", e.getMessage());
+                return TaskExecutionResult.ko(outputs);
+            }
+
+            return TaskExecutionResult.ok();
         }
     }
 

--- a/engine/src/test/java/com/chutneytesting/task/domain/TaskTemplateParserV2Test.java
+++ b/engine/src/test/java/com/chutneytesting/task/domain/TaskTemplateParserV2Test.java
@@ -2,7 +2,7 @@ package com.chutneytesting.task.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.chutneytesting.task.TestTaskTemplateFactory.ComplexeTask;
+import com.chutneytesting.task.TestTaskTemplateFactory.ComplexTask;
 import com.chutneytesting.task.TestTaskTemplateFactory.TwoConstructorTask;
 import com.chutneytesting.task.TestTaskTemplateFactory.TwoParametersTask;
 import com.chutneytesting.task.TestTaskTemplateFactory.ValidSimpleTask;
@@ -24,13 +24,13 @@ public class TaskTemplateParserV2Test {
     }
 
     @Test
-    public void complexe_task_parsing() {
-        ResultOrError<TaskTemplate, ParsingError> parsingResult = parser.parse(ComplexeTask.class);
+    public void complex_task_parsing() {
+        ResultOrError<TaskTemplate, ParsingError> parsingResult = parser.parse(ComplexTask.class);
 
         assertThat(parsingResult.isOk()).isTrue();
         TaskTemplate taskTemplate = parsingResult.result();
-        assertThat(taskTemplate.identifier()).isEqualTo("complexe");
-        assertThat(taskTemplate.implementationClass()).isEqualTo(ComplexeTask.class);
+        assertThat(taskTemplate.identifier()).isEqualTo("complex");
+        assertThat(taskTemplate.implementationClass()).isEqualTo(ComplexTask.class);
         assertThat(taskTemplate.parameters()).hasSize(2);
     }
 

--- a/engine/src/test/java/com/chutneytesting/task/domain/TaskTemplateV2Test.java
+++ b/engine/src/test/java/com/chutneytesting/task/domain/TaskTemplateV2Test.java
@@ -3,7 +3,7 @@ package com.chutneytesting.task.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-import com.chutneytesting.task.TestTaskTemplateFactory.ComplexeTask;
+import com.chutneytesting.task.TestTaskTemplateFactory.ComplexTask;
 import com.chutneytesting.task.TestTaskTemplateFactory.Pojo;
 import com.chutneytesting.task.TestTaskTemplateFactory.TwoParametersTask;
 import com.chutneytesting.task.TestTaskTemplateFactory.ValidSimpleTask;
@@ -46,8 +46,8 @@ public class TaskTemplateV2Test {
     }
 
     @Test
-    public void task_with_complexe_parameters_instantiation_and_execution() {
-        TaskTemplate taskTemplate = new TaskTemplateParserV2().parse(ComplexeTask.class).result();
+    public void task_with_complex_parameters_instantiation_and_execution() {
+        TaskTemplate taskTemplate = new TaskTemplateParserV2().parse(ComplexTask.class).result();
         String stringValue = UUID.randomUUID().toString();
         Pojo pojo = new Pojo("1", "2");
         Task task = taskTemplate.create(Arrays.asList(
@@ -55,7 +55,7 @@ public class TaskTemplateV2Test {
             new TypeBasedParameterResolver<>(Pojo.class, p -> pojo)
         ));
 
-        assertThat(task).isExactlyInstanceOf(ComplexeTask.class);
+        assertThat(task).isExactlyInstanceOf(ComplexTask.class);
 
         TaskExecutionResult executionResult = task.execute();
 

--- a/task-impl/src/main/java/com/chutneytesting/task/sql/SqlTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/sql/SqlTask.java
@@ -22,6 +22,7 @@ public class SqlTask implements Task {
     private final List<String> statements;
 
     private final DefaultSqlClientFactory clientFactory = new DefaultSqlClientFactory();
+    private final int NB_LOGGED_ROWS = 10;
 
     public SqlTask(Target target, Logger logger, @Input("statements") List<String> statements) {
         this.target = target;
@@ -40,9 +41,13 @@ public class SqlTask implements Task {
                 try {
                     Records result = sqlClient.execute(statement);
                     records.add(result);
-                    logger.info(result.printable());
+                    logger.info(result.printable(NB_LOGGED_ROWS));
                 } catch (SQLException e) {
                     logger.error(e.getMessage() + " for " + statement + "; Vendor error code: " + e.getErrorCode());
+                    records.add(sqlClient.emptyRecords());
+                    failure.set(true);
+                } catch (Exception e) {
+                    logger.error(e.getMessage());
                     records.add(sqlClient.emptyRecords());
                     failure.set(true);
                 }

--- a/task-impl/src/main/java/com/chutneytesting/task/sql/core/DefaultSqlClientFactory.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/sql/core/DefaultSqlClientFactory.java
@@ -1,11 +1,15 @@
 package com.chutneytesting.task.sql.core;
 
+import static java.util.Optional.ofNullable;
+
+import com.chutneytesting.task.spi.injectable.Target;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import com.chutneytesting.task.spi.injectable.Target;
 import java.util.Properties;
 
 public class DefaultSqlClientFactory implements SqlClientFactory {
+
+    private final int DEFAULT_MAX_FETCH_SIZE = 1000;
 
     @Override
     public SqlClient create(Target target) {
@@ -22,6 +26,6 @@ public class DefaultSqlClientFactory implements SqlClientFactory {
         final HikariConfig config = new HikariConfig(props);
         final HikariDataSource ds = new HikariDataSource(config);
 
-        return new SqlClient(ds);
+        return new SqlClient(ds, ofNullable(target.properties().get("maxFetchSize")).map(Integer::getInteger).orElse(DEFAULT_MAX_FETCH_SIZE));
     }
 }

--- a/task-impl/src/main/java/com/chutneytesting/task/sql/core/NonOptimizedQueryException.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/sql/core/NonOptimizedQueryException.java
@@ -1,0 +1,9 @@
+package com.chutneytesting.task.sql.core;
+
+public class NonOptimizedQueryException extends RuntimeException {
+
+    public NonOptimizedQueryException() {
+        super("Query fetched too many rows. Please try to refine your query.");
+    }
+
+}

--- a/task-impl/src/main/java/com/chutneytesting/task/sql/core/Records.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/sql/core/Records.java
@@ -20,8 +20,13 @@ public class Records {
     }
 
     public List<Map<String, Object>> toListOfMaps() {
-        final List<Map<String, Object>> listOfMaps = new ArrayList<>(rows.size());
-        for (List<Object> row : rows) {
+        return this.toListOfMaps(rows.size());
+    }
+
+    public List<Map<String, Object>> toListOfMaps(int n) {
+        final int limit = Math.min(n, rows.size());
+        final List<Map<String, Object>> listOfMaps = new ArrayList<>(limit);
+        for (List<Object> row : rows.subList(0, limit)) {
             final Map<String, Object> aRow = new LinkedHashMap<>(headers.size());
             for (int j = 0; j < headers.size(); j++) {
                 aRow.put(headers.get(j), row.get(j));
@@ -41,24 +46,24 @@ public class Records {
         return matrix;
     }
 
-    public String printable() {
+    public String printable(int limit) {
         StringBuilder sb = new StringBuilder();
-        Map<String, Integer> maxColumnLength = maximumColumnLength();
+        Map<String, Integer> maxColumnLength = maximumColumnLength(limit);
         sb.append(tableHeaders(maxColumnLength));
-        sb.append(tableRows(maxColumnLength));
+        sb.append(tableRows(limit, maxColumnLength));
         return sb.toString();
     }
 
-    public Map<String, Integer> maximumColumnLength() {
+    public Map<String, Integer> maximumColumnLength(int limit) {
         return headers.stream()
             .collect(Collectors.toMap(
                 h -> h,
-                this::maximumLength
+                h -> this.maximumLength(h, limit)
             ));
     }
 
-    private int maximumLength(String header) {
-        List<Map<String, Object>> list = toListOfMaps();
+    private int maximumLength(String header, int limit) {
+        List<Map<String, Object>> list = toListOfMaps(limit);
         Integer integer = list.stream()
             .map(r -> r.get(header).toString().length())
             .max(Integer::compare)
@@ -88,9 +93,9 @@ public class Records {
         return " ".repeat(i);
     }
 
-    public String tableRows(Map<String, Integer> maximumColumnLength) {
-        List<Map<String, Object>> rows = this.toListOfMaps();
-        List<String> lines = rows.stream().map(row -> rowAsString(row, maximumColumnLength)).collect(Collectors.toList());
+    public String tableRows(int limit, Map<String, Integer> maximumColumnLength) {
+        List<Map<String, Object>> rows = this.toListOfMaps(limit);
+        List<String> lines = rows.stream().limit(limit).map(row -> rowAsString(row, maximumColumnLength)).collect(Collectors.toList());
         StringBuilder sb = new StringBuilder();
         lines.forEach(sb::append);
         return sb.toString();

--- a/task-impl/src/main/java/com/chutneytesting/task/sql/core/SqlClient.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/sql/core/SqlClient.java
@@ -95,7 +95,12 @@ public class SqlClient {
 
         private static List<List<Object>> createRows(ResultSet rs, int columnCount) throws SQLException {
             final List<List<Object>> rows = new ArrayList<>();
+            int j = 0;
             while (rs.next()) {
+                if (j++ > 100000) {
+                    throw new NonOptimizedQueryException();
+                }
+
                 if (!hasEnoughAvailableMemory()) {
                     throw new NotEnoughMemoryException(usedMemory(), MAX_MEMORY, "Query fetched " + rows.size() + " rows");
                 }

--- a/task-impl/src/test/java/com/chutneytesting/task/sql/core/RecordsTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/sql/core/RecordsTest.java
@@ -1,9 +1,10 @@
 package com.chutneytesting.task.sql.core;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.groovy.util.Maps;
@@ -12,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class RecordsTest {
 
     @Test
-    void toListOfMaps() {
+    void toListOfMaps_should_return_all_rows() {
 
         Records records = new Records(-1, List.of("First Name", "Name", "Address"), List.of(
             List.of("Henri", "Martin", "Paris"),
@@ -22,8 +23,37 @@ class RecordsTest {
 
         List<Map<String, Object>> actual = records.toListOfMaps();
 
+        assertThat(actual).hasSize(3);
         assertThat(actual.get(1).get("Name")).isEqualTo("Dupont");
         assertThat(actual.get(2).get("Address")).isEqualTo("Chartres");
+
+    }
+
+    @Test
+    void toListOfMaps_should_return_limited_number_of_rows() {
+
+        Records records = new Records(-1, List.of("First Name", "Name", "Address"), List.of(
+            List.of("Henri", "Martin", "Paris"),
+            List.of("Jean", "Dupont", "Bordeaux"),
+            List.of("Charles", "Magne", "Chartres")
+        ));
+
+        List<Map<String, Object>> actual = records.toListOfMaps(2);
+
+        assertThat(actual).hasSize(2);
+
+    }
+
+    @Test
+    void toListOfMaps_should_not_out_bound() {
+
+        Records records = new Records(-1, List.of("First Name", "Name", "Address"), List.of(
+            List.of("Henri", "Martin", "Paris")
+        ));
+
+        List<Map<String, Object>> actual = records.toListOfMaps(2);
+
+        assertThat(actual).hasSize(1);
 
     }
 
@@ -45,20 +75,37 @@ class RecordsTest {
 
     @Test
     void should_print_nothing_without_headers() {
-        Records records = new Records(-1, Collections.emptyList(), Collections.emptyList());
-        String actual = records.tableHeaders(records.maximumColumnLength());
+        Records records = new Records(-1, emptyList(), emptyList());
+        String actual = records.tableHeaders(records.maximumColumnLength(0));
         assertThat(actual).isEmpty();
     }
 
 
     @Test
-    void column_length_should_be_header_or_value_max_lenght() {
-        List<String> headers = Arrays.asList("lengthOf11", "Header is longer", "7");
-        List<List<Object>> rows = Collections.singletonList(Arrays.asList("12345678910", "16", "1234567"));
+    void column_length_should_equal_header_or_value_max_length() {
+        List<String> headers = asList("lengthOf11", "Header is longer", "7");
+        List<List<Object>> rows = singletonList(asList("12345678910", "16", "1234567"));
 
         Records sut = new Records(-1, headers, rows);
 
-        Map<String, Integer> actual = sut.maximumColumnLength();
+        Map<String, Integer> actual = sut.maximumColumnLength(1);
+
+        assertThat(actual.get("lengthOf11")).isEqualTo(11);
+        assertThat(actual.get("Header is longer")).isEqualTo(16);
+        assertThat(actual.get("7")).isEqualTo(7);
+    }
+
+    @Test
+    void column_length_should_be_calculated_from_limited_number_of_rows() {
+        List<String> headers = asList("lengthOf11", "Header is longer", "7");
+        List<List<Object>> rows = asList(
+            asList("12345678910", "16", "1234567"),
+            asList("veryveryvery long value", "16", "1234567")
+        );
+
+        Records sut = new Records(-1, headers, rows);
+
+        Map<String, Integer> actual = sut.maximumColumnLength(1);
 
         assertThat(actual.get("lengthOf11")).isEqualTo(11);
         assertThat(actual.get("Header is longer")).isEqualTo(16);
@@ -67,12 +114,12 @@ class RecordsTest {
 
     @Test
     void should_print_formatted_headers() {
-        List<String> headers = Arrays.asList("lengthOf11", "2", "7");
-        List<List<Object>> rows = Collections.singletonList(Arrays.asList("12345678910", "12", "1234567"));
+        List<String> headers = asList("lengthOf11", "2", "7");
+        List<List<Object>> rows = singletonList(asList("12345678910", "12", "1234567"));
 
         Records sut = new Records(-1, headers, rows);
 
-        String actual = sut.tableHeaders(sut.maximumColumnLength());
+        String actual = sut.tableHeaders(sut.maximumColumnLength(1));
 
         assertThat(actual).isEqualTo(
             "| lengthOf11  | 2  | 7       |\n" +
@@ -82,8 +129,8 @@ class RecordsTest {
 
     @Test
     void should_print_formatted_rows() {
-        List<String> headers = Arrays.asList("lengthOf11", "Header is longer", "7");
-        List<List<Object>> rows = Collections.singletonList(Arrays.asList("12345678910", "42", "1234567"));
+        List<String> headers = asList("lengthOf11", "Header is longer", "7");
+        List<List<Object>> rows = singletonList(asList("12345678910", "42", "1234567"));
         Map<String, Integer> maxLength = Maps.of(
             "lengthOf11", 11,
             "Header is longer", 16,

--- a/task-impl/src/test/java/com/chutneytesting/task/sql/core/SqlClientTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/sql/core/SqlClientTest.java
@@ -17,7 +17,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
-public class DefaultSqlConnectorTest {
+public class SqlClientTest {
 
     private static String DB_NAME = "test";
     private Target sqlTarget = TestTarget.TestTargetBuilder.builder()

--- a/tools/src/main/java/com/chutneytesting/tools/ChutneyMemoryInfo.java
+++ b/tools/src/main/java/com/chutneytesting/tools/ChutneyMemoryInfo.java
@@ -1,0 +1,26 @@
+package com.chutneytesting.tools;
+
+public class ChutneyMemoryInfo {
+
+    public static final long MAX_MEMORY = Runtime.getRuntime().maxMemory(); // Fixed at startup
+    public static final int MINIMUM_MEMORY_PERCENTAGE_REQUIRED = 5;
+    public static final long MINIMUM_MEMORY_REQUIRED = (MAX_MEMORY / 100) * MINIMUM_MEMORY_PERCENTAGE_REQUIRED;
+
+    public static long committedMemory() {
+        return Runtime.getRuntime().totalMemory();
+    }
+
+    public static long availableMemory() {
+        return MAX_MEMORY - committedMemory();
+    }
+
+    public static long usedMemory() {
+        Runtime runtime = Runtime.getRuntime();
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
+
+    public static boolean hasEnoughAvailableMemory() {
+        return availableMemory() > MINIMUM_MEMORY_REQUIRED;
+    }
+
+}

--- a/tools/src/main/java/com/chutneytesting/tools/NotEnoughMemoryException.java
+++ b/tools/src/main/java/com/chutneytesting/tools/NotEnoughMemoryException.java
@@ -1,0 +1,20 @@
+package com.chutneytesting.tools;
+
+import java.text.DecimalFormat;
+
+public class NotEnoughMemoryException extends RuntimeException {
+
+    public NotEnoughMemoryException(long usedMemory, long totalMemory, String customMsg) {
+        super(
+            "Running step was stopped to prevent application crash."
+                + toMegaByte(usedMemory) + "MB memory used of " + toMegaByte(totalMemory) + "MB total."
+                + "\n" + "Current step may not be the cause."
+                + "\n" + customMsg
+        );
+    }
+
+    private static String toMegaByte(long value) {
+        return new DecimalFormat("#.##").format(value / (double)(1204 * 1024));
+    }
+
+}


### PR DESCRIPTION
#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

Add a tool to get runtime mem info and an exception.
Use it while fetching row in SQL task.

I also added limits to logged rows and failed the task if OOM is about to happen.

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

SQL task implementation is not very flexible and uses an inner static class.
So I use static methods on the memmory info tool, which make everything harder to test.
So I tried to mimic the behaviour using a fake OOM task as a workaround. SQL task might need to be refresh someday, also to take into account possible multi-resultset queries.

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [x] No git conflict
