### PR TITLE
fix(server): Backup all environments

### DIFF
--- a/server/src/main/java/com/chutneytesting/admin/infra/storage/FileSystemBackupRepository.java
+++ b/server/src/main/java/com/chutneytesting/admin/infra/storage/FileSystemBackupRepository.java
@@ -18,6 +18,7 @@ import com.chutneytesting.tools.Try;
 import com.chutneytesting.tools.ZipUtils;
 import com.chutneytesting.tools.file.FileUtils;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.io.BufferedOutputStream;
@@ -63,6 +64,7 @@ public class FileSystemBackupRepository implements BackupRepository {
 
     private final ObjectMapper om = new ObjectMapper()
         .findAndRegisterModules()
+        .disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
         .enable(SerializationFeature.INDENT_OUTPUT)
         .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 


### PR DESCRIPTION
OutputStream was autoclosed by ObjectMapper

#### Issue Number
fixes #457 
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

Default behavior of ObjectMapper is to close the outputStream after writing to it.
Since we need to write multiple environments in a loop, we have to specify it. Then, the stream is closed by the try-with-resources.

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [x] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
