### PR TITLE
fix(task): SQL result with duplicated column name

### DIFF
--- a/server/src/test/resources/blackbox/tasks/sql.feature
+++ b/server/src/test/resources/blackbox/tasks/sql.feature
@@ -90,7 +90,7 @@ Feature: SQL Task test
         And the report contains record results
             Do compare
                 With actual ${#json(#report, "$.report.steps[-1:].stepOutputs.recordResult").toString()}
-                With expected [[{"affectedRows":-1,"headers":["ID","NAME","EMAIL"],"rows":[[1,"laitue","laitue@fake.com"],[2,"carotte","kakarot@fake.db"]]}]]
+                With expected [[{"affectedRows":-1,"headers":["ID","NAME","EMAIL"],"rows":[[1,"laitue","laitue@fake.com"],[2,"carotte","kakarot@fake.db"]],"columns":[{"name":"ID","index":0},{"name":"NAME","index":1},{"name":"EMAIL","index":2}],"records":[{},{}]}]]
                 With mode equals
 
     Scenario: Sql query wrong table

--- a/task-impl/src/main/java/com/chutneytesting/task/sql/core/Cell.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/sql/core/Cell.java
@@ -1,0 +1,42 @@
+package com.chutneytesting.task.sql.core;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class Cell {
+    static final Cell NONE = new Cell(Column.NONE, Optional.empty());
+
+    public final Column column;
+    public final Object value;
+
+    public Cell(Column column, Object value) {
+        this.column = column;
+        this.value = value;
+    }
+
+    String print(int maxLength) {
+        return value.toString() + " ".repeat(maxLength - value.toString().length());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Cell cell = (Cell) o;
+        return column.equals(cell.column) &&
+            value.equals(cell.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(column, value);
+    }
+
+    @Override
+    public String toString() {
+        return "Cell{" +
+            "column=" + column.name +
+            ", value=" + value +
+            '}';
+    }
+}

--- a/task-impl/src/main/java/com/chutneytesting/task/sql/core/Column.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/sql/core/Column.java
@@ -1,0 +1,45 @@
+package com.chutneytesting.task.sql.core;
+
+import java.util.Objects;
+
+public class Column {
+    static final Column NONE = new Column("", -1);
+
+    public final String name;
+    public final int index;
+
+    public Column(String name, int index) {
+        this.name = name;
+        this.index = index;
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public String printHeader(int length) {
+        return name + " ".repeat(length - name.length());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Column column = (Column) o;
+        return index == column.index &&
+            Objects.equals(name, column.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, index);
+    }
+
+    @Override
+    public String toString() {
+        return "Column{" +
+            "name='" + name + '\'' +
+            ", index=" + index +
+            '}';
+    }
+}

--- a/task-impl/src/main/java/com/chutneytesting/task/sql/core/Row.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/sql/core/Row.java
@@ -1,0 +1,68 @@
+package com.chutneytesting.task.sql.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class Row {
+    final List<Cell> cells;
+
+    public Row(List<Cell> values) {
+        this.cells = values;
+    }
+
+    public Cell get(Column column) {
+        return cells.stream()
+            .filter(v -> v.column.equals(column))
+            .findFirst()
+            .orElse(Cell.NONE);
+    }
+
+    public Cell get(String header) {
+        return cells.stream()
+            .filter(v -> v.column.name.equals(header))
+            .findFirst()
+            .orElse(Cell.NONE);
+    }
+
+    public Cell get(int index) {
+        return cells.stream()
+            .filter(v -> v.column.index == index)
+            .findFirst()
+            .orElse(Cell.NONE);
+    }
+
+    public String print(Map<Column, Integer> maxLength) {
+        StringBuilder sb = new StringBuilder();
+        if (!cells.isEmpty()) {
+            sb.append("|");
+            cells.forEach(c ->
+                sb.append(" ")
+                .append(c.print(maxLength.get(c.column)))
+                .append(" |")
+            );
+        }
+        sb.append("\n");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Row row = (Row) o;
+        return cells.equals(row.cells);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cells);
+    }
+
+    @Override
+    public String toString() {
+        return "Row{" +
+            "cells=" + cells +
+            '}';
+    }
+}

--- a/task-impl/src/test/java/com/chutneytesting/task/sql/core/RecordsTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/sql/core/RecordsTest.java
@@ -10,18 +10,55 @@ import java.util.Map;
 import org.apache.groovy.util.Maps;
 import org.junit.jupiter.api.Test;
 
-class RecordsTest {
+public class RecordsTest {
+
+
+    @Test
+    void getHeaders() {
+
+        Column c0 = new Column("Test", 0);
+        Column c1 = new Column("Letter", 1);
+        Column c2 = new Column("Letter", 2);
+        Column c3 = new Column("Number", 3);
+        Column c4 = new Column("Number", 4);
+
+        Records actual = new Records(-1, List.of(c0, c1, c2, c3, c4), emptyList());
+
+        assertThat(actual.headers).isEqualTo(List.of("Test", "Letter", "Letter", "Number", "Number"));
+    }
+
+    @Test
+    void getRows() {
+        Column fake = new Column("fake", 0);
+
+        List<Row> records = List.of(
+            new Row(List.of(new Cell(fake, "A"), new Cell(fake, "B"))),
+            new Row(List.of(new Cell(fake, "AA"), new Cell(fake, "BB")))
+        );
+
+        Records actual = new Records(-1, emptyList(), records);
+
+        assertThat(actual.rows.get(0)).isEqualTo(List.of("A", "B"));
+        assertThat(actual.rows.get(1)).isEqualTo(List.of("AA", "BB"));
+
+    }
 
     @Test
     void toListOfMaps_should_return_all_rows() {
 
-        Records records = new Records(-1, List.of("First Name", "Name", "Address"), List.of(
-            List.of("Henri", "Martin", "Paris"),
-            List.of("Jean", "Dupont", "Bordeaux"),
-            List.of("Charles", "Magne", "Chartres")
-        ));
+        Column c0 = new Column("First Name", 0);
+        Column c1 = new Column("Name", 1);
+        Column c2 = new Column("Address", 2);
 
-        List<Map<String, Object>> actual = records.toListOfMaps();
+        List<Row> records = List.of(
+            new Row(List.of(new Cell(c0, "Henri"), new Cell(c1, "Martin"), new Cell(c2, "Paris"))),
+            new Row(List.of(new Cell(c0, "Jean"), new Cell(c1, "Dupont"), new Cell(c2, "Bordeaux"))),
+            new Row(List.of(new Cell(c0, "Charles"), new Cell(c1, "Magne"), new Cell(c2, "Chartres")))
+        );
+
+        Records sut = new Records(-1, List.of(c0, c1, c2), records);
+
+        List<Map<String, Object>> actual = sut.toListOfMaps();
 
         assertThat(actual).hasSize(3);
         assertThat(actual.get(1).get("Name")).isEqualTo("Dupont");
@@ -32,13 +69,19 @@ class RecordsTest {
     @Test
     void toListOfMaps_should_return_limited_number_of_rows() {
 
-        Records records = new Records(-1, List.of("First Name", "Name", "Address"), List.of(
-            List.of("Henri", "Martin", "Paris"),
-            List.of("Jean", "Dupont", "Bordeaux"),
-            List.of("Charles", "Magne", "Chartres")
-        ));
+        Column c0 = new Column("First Name", 0);
+        Column c1 = new Column("Name", 1);
+        Column c2 = new Column("Address", 2);
 
-        List<Map<String, Object>> actual = records.toListOfMaps(2);
+        List<Row> records = List.of(
+            new Row(List.of(new Cell(c0, "Henri"), new Cell(c1, "Martin"), new Cell(c2, "Paris"))),
+            new Row(List.of(new Cell(c0, "Jean"), new Cell(c1, "Dupont"), new Cell(c2, "Bordeaux"))),
+            new Row(List.of(new Cell(c0, "Charles"), new Cell(c1, "Magne"), new Cell(c2, "Chartres")))
+        );
+
+        Records sut = new Records(-1, List.of(c0, c1, c2), records);
+
+        List<Map<String, Object>> actual = sut.toListOfMaps(2);
 
         assertThat(actual).hasSize(2);
 
@@ -47,11 +90,17 @@ class RecordsTest {
     @Test
     void toListOfMaps_should_not_out_bound() {
 
-        Records records = new Records(-1, List.of("First Name", "Name", "Address"), List.of(
-            List.of("Henri", "Martin", "Paris")
-        ));
+        Column c0 = new Column("First Name", 0);
+        Column c1 = new Column("Name", 1);
+        Column c2 = new Column("Address", 2);
 
-        List<Map<String, Object>> actual = records.toListOfMaps(2);
+        List<Row> records = List.of(
+            new Row(List.of(new Cell(c0, "Henri"), new Cell(c1, "Martin"), new Cell(c2, "Paris")))
+        );
+
+        Records sut = new Records(-1, List.of(c0, c1, c2), records);
+
+        List<Map<String, Object>> actual = sut.toListOfMaps(2);
 
         assertThat(actual).hasSize(1);
 
@@ -60,13 +109,19 @@ class RecordsTest {
     @Test
     void toMatrix() {
 
-        Records records = new Records(-1, List.of("First Name", "Name", "Address"), List.of(
-            List.of("Henri", "Martin", "Paris"),
-            List.of("Jean", "Dupont", "Bordeaux"),
-            List.of("Charles", "Magne", "Chartres")
-        ));
+        Column c0 = new Column("First Name", 0);
+        Column c1 = new Column("Name", 1);
+        Column c2 = new Column("Address", 2);
 
-        Object[][] actual = records.toMatrix();
+        List<Row> records = List.of(
+            new Row(List.of(new Cell(c0, "Henri"), new Cell(c1, "Martin"), new Cell(c2, "Paris"))),
+            new Row(List.of(new Cell(c0, "Jean"), new Cell(c1, "Dupont"), new Cell(c2, "Bordeaux"))),
+            new Row(List.of(new Cell(c0, "Charles"), new Cell(c1, "Magne"), new Cell(c2, "Chartres")))
+        );
+
+        Records sut = new Records(-1, List.of(c0, c1, c2), records);
+
+        Object[][] actual = sut.toMatrix();
 
         assertThat(actual[1][1]).isEqualTo("Dupont");
         assertThat(actual[2][2]).isEqualTo("Chartres");
@@ -83,40 +138,52 @@ class RecordsTest {
 
     @Test
     void column_length_should_equal_header_or_value_max_length() {
-        List<String> headers = asList("lengthOf11", "Header is longer", "7");
-        List<List<Object>> rows = singletonList(asList("12345678910", "16", "1234567"));
+        Column c0 = new Column("lengthOf11", 0);
+        Column c1 = new Column("Header is longer", 1);
+        Column c2 = new Column("7", 2);
+
+        List<Column> headers = asList(c0, c1, c2);
+        List<Row> rows = singletonList(new Row(List.of(new Cell(c0, "12345678910"), new Cell(c1,"16"), new Cell(c2,"1234567"))));
 
         Records sut = new Records(-1, headers, rows);
 
-        Map<String, Integer> actual = sut.maximumColumnLength(1);
+        Map<Column, Integer> actual = sut.maximumColumnLength(1);
 
-        assertThat(actual.get("lengthOf11")).isEqualTo(11);
-        assertThat(actual.get("Header is longer")).isEqualTo(16);
-        assertThat(actual.get("7")).isEqualTo(7);
+        assertThat(actual.get(c0)).isEqualTo(11);
+        assertThat(actual.get(c1)).isEqualTo(16);
+        assertThat(actual.get(c2)).isEqualTo(7);
     }
 
     @Test
     void column_length_should_be_calculated_from_limited_number_of_rows() {
-        List<String> headers = asList("lengthOf11", "Header is longer", "7");
-        List<List<Object>> rows = asList(
-            asList("12345678910", "16", "1234567"),
-            asList("veryveryvery long value", "16", "1234567")
+        Column c0 = new Column("lengthOf11", 0);
+        Column c1 = new Column("Header is longer", 1);
+        Column c2 = new Column("same", 2);
+        Column c3 = new Column("same", 3);
+
+        List<Column> headers = asList(c0, c1, c2, c3);
+        List<Row> rows = asList(
+            new Row(List.of(new Cell(c0, "12345678910"), new Cell(c1,"16"), new Cell(c2,"123"), new Cell(c3, "ABC"))),
+            new Row(List.of(new Cell(c0, "veryveryvery long value"), new Cell(c1,"42"), new Cell(c2,"123"), new Cell(c3, "ABC")))
         );
 
         Records sut = new Records(-1, headers, rows);
 
-        Map<String, Integer> actual = sut.maximumColumnLength(1);
+        Map<Column, Integer> actual = sut.maximumColumnLength(1);
 
-        assertThat(actual.get("lengthOf11")).isEqualTo(11);
-        assertThat(actual.get("Header is longer")).isEqualTo(16);
-        assertThat(actual.get("7")).isEqualTo(7);
+        assertThat(actual.get(c0)).isEqualTo(11);
+        assertThat(actual.get(c1)).isEqualTo(16);
+        assertThat(actual.get(c2)).isEqualTo(4);
     }
 
     @Test
     void should_print_formatted_headers() {
-        List<String> headers = asList("lengthOf11", "2", "7");
-        List<List<Object>> rows = singletonList(asList("12345678910", "12", "1234567"));
+        Column c0 = new Column("lengthOf11", 0);
+        Column c1 = new Column("2", 1);
+        Column c2 = new Column("7", 2);
 
+        List<Column> headers = asList(c0, c1, c2);
+        List<Row> rows = singletonList(new Row(List.of(new Cell(c0, "12345678910"), new Cell(c1,"12"), new Cell(c2,"1234567"))));
         Records sut = new Records(-1, headers, rows);
 
         String actual = sut.tableHeaders(sut.maximumColumnLength(1));
@@ -129,8 +196,13 @@ class RecordsTest {
 
     @Test
     void should_print_formatted_rows() {
-        List<String> headers = asList("lengthOf11", "Header is longer", "7");
-        List<List<Object>> rows = singletonList(asList("12345678910", "42", "1234567"));
+        Column c0 = new Column("lengthOf11", 0);
+        Column c1 = new Column("2", 1);
+        Column c2 = new Column("7", 2);
+
+        List<Column> headers = asList(c0, c1, c2);
+
+        List<Row> rows = singletonList(new Row(List.of(new Cell(c0, "12345678910"), new Cell(c1,"42"), new Cell(c2,"1234567"))));
         Map<String, Integer> maxLength = Maps.of(
             "lengthOf11", 11,
             "Header is longer", 16,
@@ -147,5 +219,27 @@ class RecordsTest {
         String actual = sut.rowAsString(row, maxLength);
 
         assertThat(actual).isEqualTo("| 12345678910 | 42               | 1234567 |\n");
+    }
+
+    @Test
+    void should_accept_duplicated_headers() {
+
+        Column c0 = new Column("X", 0);
+        Column c1 = new Column("X", 1);
+        Column c2 = new Column("X", 2);
+
+        Records records = new Records(-1, List.of(c0, c1, c2), List.of(
+            new Row(List.of(new Cell(c0, "A"), new Cell(c1,"B"), new Cell(c2,"C"))),
+            new Row(List.of(new Cell(c0, "D"), new Cell(c1,"E"), new Cell(c2,"F")))
+        ));
+
+        String actual = records.printable(2);
+
+        assertThat(actual).isEqualTo(
+            "| X | X | X |\n" +
+            "-------------\n" +
+            "| A | B | C |\n" +
+            "| D | E | F |\n"
+        );
     }
 }

--- a/task-impl/src/test/java/com/chutneytesting/task/sql/core/SqlClientTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/sql/core/SqlClientTest.java
@@ -13,7 +13,6 @@ import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,15 +51,19 @@ public class SqlClientTest {
 
     @Test
     public void should_return_headers_and_rows_on_select_query() throws SQLException {
-        List<Object> firstTuple = Arrays.asList(1, "laitue", "laitue@fake.com");
-        List<Object> secondTuple = Arrays.asList(2, "carotte", "kakarot@fake.db");
-        List<Object> thirdTuple = Arrays.asList(3, "tomate", "null");
+        Column c0 = new Column("ID", 0);
+        Column c1 = new Column("NAME", 1);
+        Column c2 = new Column("EMAIL", 2);
+
+        Row firstTuple =  new Row(List.of(new Cell(c0, 1), new Cell(c1, "laitue"), new Cell(c2, "laitue@fake.com")));
+        Row secondTuple = new Row(List.of(new Cell(c0, 2), new Cell(c1, "carotte"), new Cell(c2, "kakarot@fake.db")));
+        Row thirdTuple =  new Row(List.of(new Cell(c0, 3), new Cell(c1, "tomate"), new Cell(c2, "null")));
 
         SqlClient sqlClient = new DefaultSqlClientFactory().create(sqlTarget);
-        Records records = sqlClient.execute("select * from users");
+        Records actual = sqlClient.execute("select * from users");
 
-        assertThat(records.headers).containsOnly("ID", "NAME", "EMAIL");
-        assertThat(records.rows).containsExactly(firstTuple, secondTuple, thirdTuple);
+        assertThat(actual.headers).containsOnly("ID", "NAME", "EMAIL");
+        assertThat(actual.records).containsExactly(firstTuple, secondTuple, thirdTuple);
     }
 
     @Test
@@ -74,12 +77,13 @@ public class SqlClientTest {
     @Test
     public void should_return_count_on_count_queries() throws SQLException {
 
-        List<Object> expectedTuple = Collections.singletonList(3L);
+        Column c0 = new Column("TOTAL", 0);
+        Row expectedTuple =  new Row(Collections.singletonList(new Cell(c0, 3L)));
 
         SqlClient sqlClient = new DefaultSqlClientFactory().create(sqlTarget);
-        Records records = sqlClient.execute("SELECT COUNT(*) as total FROM USERS");
+        Records actual = sqlClient.execute("SELECT COUNT(*) as total FROM USERS");
 
-        assertThat(records.rows).containsExactly(expectedTuple);
+        assertThat(actual.records).containsExactly(expectedTuple);
     }
 
     @Test
@@ -134,27 +138,27 @@ public class SqlClientTest {
     @Test
     public void should_retrieve_columns_as_string_but_for_date_and_numeric_sql_datatypes() throws SQLException {
         SqlClient sqlClient = new DefaultSqlClientFactory().create(sqlTarget);
-        Records records = sqlClient.execute("select * from allsqltypes");
+        Records actual = sqlClient.execute("select * from allsqltypes");
 
-        Map<String, Object> onlyRecord = records.toListOfMaps().get(0);
-        assertThat(onlyRecord.get("COL_BOOLEAN")).isInstanceOf(Boolean.class);
-        assertThat(onlyRecord.get("COL_TINYINT")).isInstanceOf(Byte.class);
-        assertThat(onlyRecord.get("COL_SMALLINT")).isInstanceOf(Short.class);
-        assertThat(onlyRecord.get("COL_MEDIUMINT")).isInstanceOf(Integer.class);
-        assertThat(onlyRecord.get("COL_INTEGER")).isInstanceOf(Integer.class);
-        assertThat(onlyRecord.get("COL_BIGINT")).isInstanceOf(Long.class);
-        assertThat(onlyRecord.get("COL_FLOAT")).isInstanceOf(Float.class);
-        assertThat(onlyRecord.get("COL_DOUBLE")).isInstanceOf(Double.class);
-        assertThat(onlyRecord.get("COL_DECIMAL")).isInstanceOf(BigDecimal.class);
-        assertThat(onlyRecord.get("COL_DECIMAL")).isInstanceOf(BigDecimal.class);
-        assertThat(onlyRecord.get("COL_DATE")).isInstanceOf(Date.class);
-        assertThat(onlyRecord.get("COL_TIME")).isInstanceOf(Time.class);
-        assertThat(onlyRecord.get("COL_TIMESTAMP")).isInstanceOf(Timestamp.class);
-        assertThat(onlyRecord.get("COL_CHAR")).isInstanceOf(String.class);
-        assertThat(onlyRecord.get("COL_VARCHAR")).isInstanceOf(String.class);
+        Row onlyRecord = actual.records.get(0);
+        assertThat(onlyRecord.get("COL_BOOLEAN").value).isInstanceOf(Boolean.class);
+        assertThat(onlyRecord.get("COL_TINYINT").value).isInstanceOf(Byte.class);
+        assertThat(onlyRecord.get("COL_SMALLINT").value).isInstanceOf(Short.class);
+        assertThat(onlyRecord.get("COL_MEDIUMINT").value).isInstanceOf(Integer.class);
+        assertThat(onlyRecord.get("COL_INTEGER").value).isInstanceOf(Integer.class);
+        assertThat(onlyRecord.get("COL_BIGINT").value).isInstanceOf(Long.class);
+        assertThat(onlyRecord.get("COL_FLOAT").value).isInstanceOf(Float.class);
+        assertThat(onlyRecord.get("COL_DOUBLE").value).isInstanceOf(Double.class);
+        assertThat(onlyRecord.get("COL_DECIMAL").value).isInstanceOf(BigDecimal.class);
+        assertThat(onlyRecord.get("COL_DECIMAL").value).isInstanceOf(BigDecimal.class);
+        assertThat(onlyRecord.get("COL_DATE").value).isInstanceOf(Date.class);
+        assertThat(onlyRecord.get("COL_TIME").value).isInstanceOf(Time.class);
+        assertThat(onlyRecord.get("COL_TIMESTAMP").value).isInstanceOf(Timestamp.class);
+        assertThat(onlyRecord.get("COL_CHAR").value).isInstanceOf(String.class);
+        assertThat(onlyRecord.get("COL_VARCHAR").value).isInstanceOf(String.class);
         // INTERVAL SQL types : cf. SqlClient.StatementConverter#isJDBCDateType(Class)
-        assertThat(onlyRecord.get("COL_INTERVAL_YEAR")).isInstanceOf(String.class);
-        assertThat(onlyRecord.get("COL_INTERVAL_SECOND")).isInstanceOf(String.class);
+        assertThat(onlyRecord.get("COL_INTERVAL_YEAR").value).isInstanceOf(String.class);
+        assertThat(onlyRecord.get("COL_INTERVAL_SECOND").value).isInstanceOf(String.class);
     }
 
     @Test


### PR DESCRIPTION
#### Issue Number
fixes #478 
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made
Add 2 attributes to the Record class in order to hold columns with the same name.

Deprecates method `toListOfMaps()` and removed as much as possible its use everywhere else.
This method is still buggy by design since it returns a `Map<String, Object>` which can't hold different values with the same key (aka column name).

Had to change the glacio test in order to reflect the two new attributes.

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [x] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
