### PR TITLE
fix(egine): Validations only set FAILURE step status

### DIFF
--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
@@ -249,7 +249,7 @@ public class Step {
                 if (!(boolean) v) {
                     failure("Validation [" + k + "] : KO (" + definition.validations.get(k).toString() + ")");
                 } else {
-                    success("Validation [" + k + "] : OK");
+                    state.addInformation("Validation [" + k + "] : OK");
                 }
             });
             return null;

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/step/StepTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/step/StepTest.java
@@ -105,12 +105,12 @@ public class StepTest {
     }
 
     @Test
-    public void should_have_success_validations_of_step_store_in_step_result() {
+    public void validations_should_inform_ok_ko_in_step_result() {
         // Given
         StepExecutor stepExecutor = mock(StepExecutor.class);
 
         Map<String, Object> validations = new HashMap<>();
-        validations.put("first assert", "${true}");
+        validations.put("first assert", "${false}");
         validations.put("second assert", "${true}");
 
         StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, null, validations, environment);
@@ -121,22 +121,21 @@ public class StepTest {
         step.execute(ScenarioExecution.createScenarioExecution(null), scenarioContext);
 
         // Then
-        assertThat(step.status()).isEqualTo(Status.SUCCESS);
         StepState state = (StepState) ReflectionTestUtils.getField(step, "state");
-        assertThat(state.errors().size()).isEqualTo(0);
-        assertThat(state.informations().size()).isEqualTo(2);
-        assertThat(state.informations().get(0)).isEqualTo("Validation [first assert] : OK");
-        assertThat(state.informations().get(1)).isEqualTo("Validation [second assert] : OK");
+        assertThat(state.errors().size()).isEqualTo(1);
+        assertThat(state.informations().size()).isEqualTo(1);
+        assertThat(state.errors().get(0)).isEqualTo("Validation [first assert] : KO (${false})");
+        assertThat(state.informations().get(0)).isEqualTo("Validation [second assert] : OK");
     }
 
     @Test
-    public void should_have_failed_validations_of_step_store_in_step_result() {
+    public void validations_should_set_failure_state() {
         // Given
         StepExecutor stepExecutor = mock(StepExecutor.class);
 
         Map<String, Object> validations = new HashMap<>();
-        validations.put("first assert", "${true}");
-        validations.put("second assert", "${false}");
+        validations.put("first assert", "${false}");
+        validations.put("second assert", "${true}");
 
         StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, null, validations, environment);
         Step step = new Step(dataEvaluator, fakeStepDefinition, Optional.empty(), stepExecutor, Lists.emptyList());
@@ -147,11 +146,6 @@ public class StepTest {
 
         // Then
         assertThat(step.status()).isEqualTo(Status.FAILURE);
-        StepState state = (StepState) ReflectionTestUtils.getField(step, "state");
-        assertThat(state.errors().size()).isEqualTo(1);
-        assertThat(state.informations().size()).isEqualTo(1);
-        assertThat(state.informations().get(0)).isEqualTo("Validation [first assert] : OK");
-        assertThat(state.errors().get(0)).isEqualTo("Validation [second assert] : KO (${false})");
     }
 
     @Test


### PR DESCRIPTION
#### Issue Number
fixes #502 

#### Describe the changes you've made

Validations change step only in FAILURE case.

#### Checklist

- [x] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
