### PR TITLE
fix(server+ui): JIRA configuration url endpoint produces plain text

### DIFF
--- a/server/src/main/java/com/chutneytesting/design/api/plugins/jira/JiraModuleController.java
+++ b/server/src/main/java/com/chutneytesting/design/api/plugins/jira/JiraModuleController.java
@@ -134,7 +134,7 @@ public class JiraModuleController {
     }
 
     @PreAuthorize("hasAuthority('SCENARIO_READ') or hasAuthority('CAMPAIGN_READ')")
-    @GetMapping(path = BASE_CONFIGURATION_URL + "/url", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(path = BASE_CONFIGURATION_URL + "/url", produces = MediaType.TEXT_PLAIN_VALUE)
     public String getConfigurationUrl() {
         JiraTargetConfiguration jiraTargetConfiguration = jiraRepository.loadServerConfiguration();
         return jiraTargetConfiguration.url;

--- a/ui/src/app/core/services/jira-plugin-configuration.service.ts
+++ b/ui/src/app/core/services/jira-plugin-configuration.service.ts
@@ -20,7 +20,7 @@ export class JiraPluginConfigurationService {
     }
 
     public getUrl(): Observable<string> {
-        return this.http.get<string>(environment.backend + this.url + '/url');
+        return this.http.get(environment.backend + this.url + '/url', {responseType: 'text'});
     }
 
     public save(configuration: JiraPluginConfiguration): Observable<String> {


### PR DESCRIPTION
#### Issue Number
fixes #508 

#### Describe the changes you've made

Ensure that JIRA configuration url is delivered throught plain text endpoint and Angular service reads it correctly as text.

#### Checklist

- [x] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
