### PR TITLE
feat(engine): Git export on shutdown

### DIFF
--- a/server/src/main/java/com/chutneytesting/ServerBootstrap.java
+++ b/server/src/main/java/com/chutneytesting/ServerBootstrap.java
@@ -1,6 +1,15 @@
 package com.chutneytesting;
 
+import com.chutneytesting.admin.domain.gitbackup.GitBackupService;
 import com.chutneytesting.execution.domain.history.ExecutionHistoryRepository;
+import com.orientechnologies.orient.core.Orient;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -10,9 +19,12 @@ import org.springframework.context.ConfigurableApplicationContext;
  */
 public class ServerBootstrap {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServerBootstrap.class);
+
     public static void main(String... args) {
         final ConfigurableApplicationContext context = start(args);
         cleanApplicationState(context);
+        registerShutdownHooks(context);
     }
 
     public static ConfigurableApplicationContext start(String... args) {
@@ -24,6 +36,58 @@ public class ServerBootstrap {
     }
 
     private static void cleanApplicationState(ConfigurableApplicationContext context) {
-        context.getBean(ExecutionHistoryRepository.class).setAllRunningExecutionsToKO();
+        int staleExecutionCount = context.getBean(ExecutionHistoryRepository.class).setAllRunningExecutionsToKO();
+        LOGGER.info("Starting with " + staleExecutionCount + " unfinished executions");
+    }
+
+    private static void registerShutdownHooks(ConfigurableApplicationContext context) {
+        try {
+            Set<Thread> thirdPartyHooks = copyThirdPartyHooks();
+            removeThirdPartyHooks(thirdPartyHooks);
+
+            Set<Thread> chutneyHooks = chutneyHooks(context);
+            Thread oneHookToRuleThemAll = new Thread(() -> hookThemAll(chutneyHooks, thirdPartyHooks));
+            Runtime.getRuntime().addShutdownHook(oneHookToRuleThemAll);
+        } catch (Exception e) {
+            LOGGER.warn("Error while setting shutdown hooks");
+        }
+    }
+
+    private static Set<Thread> copyThirdPartyHooks() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+        Class<?> appShutdownHooks = Class.forName("java.lang.ApplicationShutdownHooks");
+        Field hooksField = appShutdownHooks.getDeclaredField("hooks");
+        hooksField.setAccessible(true);
+        return new HashMap<>((IdentityHashMap<Thread, Thread>) hooksField.get(null)).keySet();
+    }
+
+    private static void removeThirdPartyHooks(Set<Thread> thirdPartyHooks) {
+        thirdPartyHooks.forEach(t -> {
+            if (!Runtime.getRuntime().removeShutdownHook(t)) {
+                LOGGER.warn("Unable to delay 3rd party shutdown hook: " + t.getName() + " from " + t.getClass().getCanonicalName() + ". This might impede Chutney's own hooks to run properly.");
+            }
+        });
+    }
+
+    private static Set<Thread> chutneyHooks(ConfigurableApplicationContext context) {
+        Set<Thread> chutneyHooks = new HashSet<>();
+        chutneyHooks.add(new Thread(() -> context.getBean(GitBackupService.class).backup()));
+        return chutneyHooks;
+    }
+
+    private static void hookThemAll(Set<Thread> chutneyHooks, Set<Thread> thirdPartyHooks) {
+        LOGGER.info("Shutdown started...");
+        chutneyHooks.forEach(ServerBootstrap::run);
+        Orient.instance().shutdown();
+        thirdPartyHooks.forEach(ServerBootstrap::run);
+        LOGGER.info("Shutdown ended");
+    }
+
+    private static void run(Thread t) {
+        try {
+            t.start();
+            t.join();
+        } catch (Throwable ignored) {
+            // ignored anyway
+        }
     }
 }

--- a/server/src/main/java/com/chutneytesting/admin/domain/gitbackup/GitBackupService.java
+++ b/server/src/main/java/com/chutneytesting/admin/domain/gitbackup/GitBackupService.java
@@ -1,9 +1,9 @@
 package com.chutneytesting.admin.domain.gitbackup;
 
 import static com.chutneytesting.admin.domain.gitbackup.ChutneyContentFSWriter.writeChutneyContent;
+import static com.chutneytesting.tools.file.FileUtils.deleteFolder;
 import static com.chutneytesting.tools.file.FileUtils.initFolder;
 
-import com.chutneytesting.tools.file.FileUtils;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -46,7 +46,7 @@ public class GitBackupService {
 
     public void remove(String name) {
         remotes.remove(name);
-        FileUtils.deleteFolder(gitRepositoryFolderPath.resolve(name));
+        deleteFolder(gitRepositoryFolderPath.resolve(name));
     }
 
     public void backup(String name) {
@@ -55,6 +55,7 @@ public class GitBackupService {
 
     public void backup(RemoteRepository remote) {
         Path workingDirectory = gitRepositoryFolderPath.resolve(remote.name);
+        cleanWorkingFolder(workingDirectory);
         gitClient.initRepository(remote, workingDirectory);
         gitClient.update(remote, workingDirectory);
         writeChutneyContent(workingDirectory, contentProviders);
@@ -63,4 +64,12 @@ public class GitBackupService {
         gitClient.push(remote, workingDirectory);
     }
 
+    private void cleanWorkingFolder(Path workingDirectory) {
+        deleteFolder(workingDirectory);
+        initFolder(workingDirectory);
+    }
+
+    public void backup() {
+        backup(remotes.getAll().get(0));
+    }
 }

--- a/server/src/main/java/com/chutneytesting/admin/infra/gitbackup/GitClientImpl.java
+++ b/server/src/main/java/com/chutneytesting/admin/infra/gitbackup/GitClientImpl.java
@@ -2,7 +2,6 @@ package com.chutneytesting.admin.infra.gitbackup;
 
 import com.chutneytesting.admin.domain.gitbackup.GitClient;
 import com.chutneytesting.admin.domain.gitbackup.RemoteRepository;
-import com.chutneytesting.tools.file.FileUtils;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
@@ -142,13 +141,6 @@ public class GitClientImpl implements GitClient {
 
     @Override
     public void initRepository(RemoteRepository remote, Path workingDirectory) {
-        try {
-            FileUtils.deleteFolder(workingDirectory);
-            Files.createDirectories(workingDirectory);
-        } catch (IOException e) {
-            throw new RuntimeException("Cannot init repository: " + remote.url + ". " + e.getMessage(), e);
-        }
-
         try (Git git = Git.init().setInitialBranch(remote.branch).setDirectory(workingDirectory.toFile()).call()) {
             git.remoteAdd()
                 .setName(remote.name)

--- a/server/src/main/java/com/chutneytesting/admin/infra/gitbackup/RemotesFileRepository.java
+++ b/server/src/main/java/com/chutneytesting/admin/infra/gitbackup/RemotesFileRepository.java
@@ -37,7 +37,7 @@ public class RemotesFileRepository implements Remotes {
         .enable(SerializationFeature.INDENT_OUTPUT)
         .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
-    RemotesFileRepository(@Value(CONFIGURATION_FOLDER_SPRING_VALUE) String storeFolderPath) throws UncheckedIOException {
+    public RemotesFileRepository(@Value(CONFIGURATION_FOLDER_SPRING_VALUE) String storeFolderPath) throws UncheckedIOException {
         this.storeFolderPath = Paths.get(storeFolderPath).resolve(ROOT_DIRECTORY_NAME);
         this.resolvedFilePath = this.storeFolderPath.resolve(REMOTES_FILE);
         initFolder(this.storeFolderPath);

--- a/server/src/main/java/com/chutneytesting/design/infra/storage/campaign/DatabaseCampaignRepository.java
+++ b/server/src/main/java/com/chutneytesting/design/infra/storage/campaign/DatabaseCampaignRepository.java
@@ -11,9 +11,6 @@ import com.chutneytesting.design.infra.storage.scenario.jdbc.TagListMapper;
 import com.google.common.collect.ImmutableMap;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -33,12 +30,6 @@ import org.springframework.stereotype.Repository;
 public class DatabaseCampaignRepository implements CampaignRepository {
 
     private static final CampaignRepositoryRowMapper CAMPAIGN_ENTITY_ROW_MAPPER = new CampaignRepositoryRowMapper();
-    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
-        .appendPattern("HH")
-        .appendLiteral(":")
-        .appendPattern("mm")
-        .toFormatter();
-
 
     private final NamedParameterJdbcTemplate uiNamedParameterJdbcTemplate;
     private final CampaignExecutionRepository campaignExecutionRepository;
@@ -163,13 +154,6 @@ public class DatabaseCampaignRepository implements CampaignRepository {
         return campaignExecutionRepository.findExecutionHistory(campaignId);
     }
 
-    private static String scheduleTimeToString(LocalTime scheduleTime) {
-        return scheduleTime != null ? scheduleTime.format(FORMATTER) : null;
-    }
-
-    private static LocalTime stringToScheduleTime(String string) {
-        return string != null ? LocalTime.parse(string, FORMATTER) : null;
-    }
 
     @SuppressWarnings("unchecked")
     private Long doUpdate(Campaign campaign) {

--- a/server/src/main/java/com/chutneytesting/design/infra/storage/scenario/compose/orient/OrientDBManager.java
+++ b/server/src/main/java/com/chutneytesting/design/infra/storage/scenario/compose/orient/OrientDBManager.java
@@ -1,5 +1,6 @@
 package com.chutneytesting.design.infra.storage.scenario.compose.orient;
 
+import com.orientechnologies.orient.core.Orient;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabasePool;
 import com.orientechnologies.orient.core.db.ODatabaseSession;
@@ -35,6 +36,7 @@ public class OrientDBManager {
     @PostConstruct
     public void init() {
         openEmbeddedOrient();
+        Orient.instance().removeShutdownHook();
     }
 
     @PreDestroy
@@ -47,7 +49,7 @@ public class OrientDBManager {
         if (orientDB.createIfNotExists(dbName, dbtype)) {
             LOGGER.info("Database created : {} {}", dbName, dbtype);
         } else {
-            LOGGER.warn("Database already exists : {}. Type {} cannot be garanteed...", dbName, dbtype);
+            LOGGER.warn("Database already exists : {}. Type {} cannot be guaranteed...", dbName, dbtype);
         }
         ODatabasePool dbPool = new ODatabasePool(orientDB, dbName, "admin", "admin", contextConfiguration());
         dbPools.put(dbName, dbPool);

--- a/server/src/test/java/com/chutneytesting/admin/domain/gitbackup/GitBackupServiceTest.java
+++ b/server/src/test/java/com/chutneytesting/admin/domain/gitbackup/GitBackupServiceTest.java
@@ -1,5 +1,6 @@
 package com.chutneytesting.admin.domain.gitbackup;
 
+import static com.chutneytesting.admin.domain.gitbackup.ChutneyContentCategory.CONF;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -9,12 +10,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.chutneytesting.admin.infra.gitbackup.ChutneyGlobalVarContent;
 import com.chutneytesting.admin.infra.gitbackup.GitClientImpl;
 import com.chutneytesting.admin.infra.gitbackup.RemotesFileRepository;
+import com.chutneytesting.tools.file.FileUtils;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -23,7 +27,7 @@ class GitBackupServiceTest {
     private final Remotes remotesMock = mock(RemotesFileRepository.class);
     private final GitClient gitClientMock = mock(GitClientImpl.class);
 
-    private final ChutneyContentProvider providerMock = mock(ChutneyGlobalVarContent.class);
+    private final ChutneyContentProvider providerMock = new FakeProvider();
     private final Set<ChutneyContentProvider> contentProviders = Set.of(providerMock);
 
     @TempDir
@@ -71,4 +75,70 @@ class GitBackupServiceTest {
         verify(remotesMock, times(1)).add(remote);
     }
 
+    @Test
+    void should_export_on_disk_even_if_remote_isnt_accessible() {
+        // Given
+        Path expectedFile = temporaryFolder.resolve("backups").resolve("git").resolve("fake").resolve(CONF.name().toLowerCase()).resolve("provider_name").resolve("fake_content.txt");
+        RemoteRepository remote = new RemoteRepository("fake", "fake", "fake", "fake", "fake");
+        when(gitClientMock.hasAccess(any())).thenReturn(false);
+
+        GitBackupService sut = new GitBackupService(new RemotesFileRepository(temporaryFolder.toString()), gitClientMock, contentProviders, temporaryFolder.toString());
+        try {
+            sut.add(remote);
+        } catch (Exception e) {
+            // ignore
+        }
+
+        // When
+        sut.backup(remote);
+
+        // Then
+        assertThat(Files.exists(expectedFile)).isTrue();
+    }
+
+    @Test
+    void should_delete_existing_content_before_export() throws IOException {
+        // Given
+        Path confPath = temporaryFolder.resolve("backups").resolve("git").resolve("fake").resolve(CONF.name().toLowerCase()).resolve("provider_name");
+        FileUtils.initFolder(confPath);
+        Path fileToDelete = confPath.resolve("to_be_removed.txt");
+        Files.write(fileToDelete, "".getBytes());
+        
+        RemoteRepository remote = new RemoteRepository("fake", "fake", "fake", "fake", "fake");
+        when(gitClientMock.hasAccess(any())).thenReturn(true);
+
+        GitBackupService sut = new GitBackupService(new RemotesFileRepository(temporaryFolder.toString()), gitClientMock, contentProviders, temporaryFolder.toString());
+
+        // When
+        sut.backup(remote);
+
+        // Then
+        assertThat(Files.exists(fileToDelete)).as("should be delete").isFalse();
+    }
+
+    static class FakeProvider implements ChutneyContentProvider {
+
+        @Override
+        public String provider() {
+            return "provider_name";
+        }
+
+        @Override
+        public ChutneyContentCategory category() {
+            return CONF;
+        }
+
+        @Override
+        public Stream<ChutneyContent> getContent() {
+            return Stream.of(
+                ChutneyContent.builder()
+                    .withName("fake_content")
+                    .withProvider(provider())
+                    .withCategory(category())
+                    .withFormat("txt")
+                    .withContent("fake content")
+                    .build()
+            );
+        }
+    }
 }

--- a/tools/src/main/java/com/chutneytesting/tools/file/FileUtils.java
+++ b/tools/src/main/java/com/chutneytesting/tools/file/FileUtils.java
@@ -22,14 +22,14 @@ public class FileUtils {
         try {
             Files.createDirectories(folderPath);
         } catch (IOException e) {
-            throw new IllegalStateException("Cannot create configuration directory: " + folderPath);
+            throw new IllegalStateException("Cannot create directory: " + folderPath);
         }
         Path testPath = folderPath.resolve("test");
         if (!Files.exists(testPath)) {
             try {
                 Files.createFile(folderPath.resolve("test"));
             } catch (IOException e) {
-                throw new UncheckedIOException("Unable to write in configuration directory: " + folderPath, e);
+                throw new UncheckedIOException("Unable to write in directory: " + folderPath, e);
             }
         }
 
@@ -44,7 +44,7 @@ public class FileUtils {
         } catch (DirectoryNotEmptyException e) {
             cleanFolder(folderPath);
         } catch (IOException e) {
-            throw new UncheckedIOException("Unable to delete in configuration directory: " + folderPath, e);
+            throw new UncheckedIOException("Unable to delete directory: " + folderPath, e);
         }
     }
 


### PR DESCRIPTION
#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

I added a shutdown hook which will export chutney content on disk.
For example, it will run before upgrading to a new version.

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

Since shutdown hooks are unordered, at startup, I copy all hooks and remove them.
They are kept to be running only AFTER  the execution of Chutney hooks.

OrientDB is not registering as a Java hook, so I had to disable the hook on the embedded instance but then run it after chutney hook.

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
