### PR TITLE
feat/finally action register task

### DIFF
--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapper.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapper.java
@@ -1,18 +1,24 @@
 package com.chutneytesting.engine.domain.execution.engine;
 
+import static java.util.Collections.emptyMap;
+
 import com.chutneytesting.engine.domain.environment.TargetImpl;
 import com.chutneytesting.engine.domain.execution.StepDefinition;
+import com.chutneytesting.engine.domain.execution.strategies.StepStrategyDefinition;
+import com.chutneytesting.engine.domain.execution.strategies.StrategyProperties;
 import com.chutneytesting.task.spi.FinallyAction;
 
 class FinallyActionMapper {
 
     StepDefinition toStepDefinition(FinallyAction finallyAction) {
         return new StepDefinition(
-            "Finally action generated for " + finallyAction.getOriginalTask(),
+            "Finally action generated for " + finallyAction.originalTask(),
             finallyAction.target()
                 .orElse(TargetImpl.NONE),
             finallyAction.actionIdentifier(),
-            null,
+            finallyAction.strategyType()
+                .map(st -> new StepStrategyDefinition(st, new StrategyProperties(finallyAction.strategyProperties().orElse(emptyMap()))))
+                .orElse(null),
             finallyAction.inputs(),
             null,
             null,

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapper.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapper.java
@@ -12,17 +12,17 @@ class FinallyActionMapper {
 
     StepDefinition toStepDefinition(FinallyAction finallyAction) {
         return new StepDefinition(
-            "Finally action generated for " + finallyAction.originalTask(),
+            finallyAction.name(),
             finallyAction.target()
                 .orElse(TargetImpl.NONE),
-            finallyAction.actionIdentifier(),
+            finallyAction.type(),
             finallyAction.strategyType()
                 .map(st -> new StepStrategyDefinition(st, new StrategyProperties(finallyAction.strategyProperties().orElse(emptyMap()))))
                 .orElse(null),
             finallyAction.inputs(),
             null,
             null,
-            null,
+            finallyAction.validations(),
             null
         );
     }

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
@@ -99,9 +99,9 @@ public class DefaultExecutionEngineTest {
 
         Step finalStep = events.get(0).step;
         assertThat(finalStep.type()).isEqualTo("");
-        assertThat(finalStep.definition().name).isEqualTo("...");
-        assertThat(finalStep.subSteps().get(0).definition().type).isEqualTo(finallyAction.actionIdentifier());
-        assertThat(finalStep.subSteps().get(0).definition().name).isEqualTo("Finally action generated for " + finallyAction.originalTask());
+        assertThat(finalStep.definition().name).isEqualTo("TearDown");
+        assertThat(finalStep.subSteps().get(0).definition().type).isEqualTo(finallyAction.type());
+        assertThat(finalStep.subSteps().get(0).definition().name).isEqualTo(finallyAction.name());
     }
 
     @Test
@@ -133,13 +133,13 @@ public class DefaultExecutionEngineTest {
 
         Step finalRootStep = events.get(0).step;
         assertThat(finalRootStep.type()).isEqualTo("");
-        assertThat(finalRootStep.definition().name).isEqualTo("...");
-        assertThat(finalRootStep.definition().steps.get(0).type).isEqualTo(finallyAction.actionIdentifier());
-        assertThat(finalRootStep.definition().steps.get(0).name).isEqualTo("Finally action generated for " + finallyAction.originalTask());
+        assertThat(finalRootStep.definition().name).isEqualTo("TearDown");
+        assertThat(finalRootStep.definition().steps.get(0).type).isEqualTo(finallyAction.type());
+        assertThat(finalRootStep.definition().steps.get(0).name).isEqualTo(finallyAction.name());
     }
 
     @Test
-    public void finally_actions_are_executed_in_reverse_order() {
+    public void finally_actions_are_executed_in_declaration_order() {
         // Given
         Reporter reporter = new Reporter();
         DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, taskExecutor);
@@ -174,9 +174,9 @@ public class DefaultExecutionEngineTest {
         // Then
         //Test order is reversed
         Step finalStep = events.get(0).step;
-        Step thirdStep = events.get(1).step;
+        Step firstStep = events.get(1).step;
         Step secondStep = events.get(2).step;
-        Step firstStep = events.get(3).step;
+        Step thirdStep = events.get(3).step;
 
         assertThat(finalStep.isParentStep()).isTrue();
 
@@ -218,8 +218,8 @@ public class DefaultExecutionEngineTest {
         // Then
         Step rootStep = endEvent.get().step;
         assertThat(rootStep.subSteps().size()).isEqualTo(1);
-        assertThat(rootStep.subSteps().get(0).definition().name).isEqualTo("...");
+        assertThat(rootStep.subSteps().get(0).definition().name).isEqualTo("TearDown");
         assertThat(rootStep.subSteps().get(0).definition().steps.size()).isEqualTo(1);
-        assertThat(rootStep.subSteps().get(0).definition().steps.get(0).name).isEqualTo("Finally action generated for " + finallyAction.originalTask());
+        assertThat(rootStep.subSteps().get(0).definition().steps.get(0).name).isEqualTo(finallyAction.name());
     }
 }

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
@@ -2,19 +2,19 @@ package com.chutneytesting.engine.domain.execution.engine;
 
 import static com.chutneytesting.engine.domain.execution.RxBus.getInstance;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.chutneytesting.engine.domain.delegation.DelegationService;
 import com.chutneytesting.engine.domain.execution.ScenarioExecution;
 import com.chutneytesting.engine.domain.execution.StepDefinition;
-import com.chutneytesting.engine.domain.execution.action.StopExecutionAction;
 import com.chutneytesting.engine.domain.execution.engine.evaluation.StepDataEvaluator;
 import com.chutneytesting.engine.domain.execution.engine.step.Step;
 import com.chutneytesting.engine.domain.execution.event.BeginStepExecutionEvent;
+import com.chutneytesting.engine.domain.execution.event.EndScenarioExecutionEvent;
 import com.chutneytesting.engine.domain.execution.report.Status;
 import com.chutneytesting.engine.domain.execution.report.StepExecutionReport;
 import com.chutneytesting.engine.domain.execution.strategies.StepExecutionStrategies;
@@ -25,10 +25,14 @@ import com.chutneytesting.engine.domain.report.Reporter;
 import com.chutneytesting.task.spi.FinallyAction;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Answers;
 
 public class DefaultExecutionEngineTest {
@@ -62,39 +66,16 @@ public class DefaultExecutionEngineTest {
         Assertions.assertThat(report.errors.get(0)).isEqualTo("Should be catch by fault barrier");
     }
 
-    @Test
-    public void should_execute_finally_actions_on_execution_end() {
+    @ParameterizedTest
+    @EnumSource(value = Status.class, names = {"SUCCESS", "FAILURE", "STOPPED"})
+    public void should_execute_finally_actions_on_scenario_end(Status endStatus) {
         //Given
         Reporter reporter = new Reporter();
         DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, taskExecutor);
 
         StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
         when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy);
-        when(strategy.execute(any(), any(), any(), any())).thenReturn(Status.STOPPED);
-
-        StrategyProperties strategyProperties = new StrategyProperties();
-        StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("retry", strategyProperties);
-        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null, null, fakeEnvironment);
-
-        ScenarioExecution mockScenarioExecution = mock(ScenarioExecution.class);
-
-        // When
-        engineUnderTest.execute(stepDefinition, mockScenarioExecution);
-        reporter.subscribeOnExecution(mockScenarioExecution.executionId).blockingLast();
-
-        // Then
-        verify(mockScenarioExecution, times(1)).executeFinallyActions(any(),any(), any());
-    }
-
-    @Test
-    public void should_execute_finally_actions_on_scenario_stop() {
-        //Given
-        Reporter reporter = new Reporter();
-        DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, taskExecutor);
-
-        StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
-        when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy);
-        when(strategy.execute(any(), any(), any(), any())).thenReturn(Status.STOPPED);
+        when(strategy.execute(any(), any(), any(), any())).thenReturn(endStatus);
 
         StrategyProperties strategyProperties = new StrategyProperties();
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("retry", strategyProperties);
@@ -108,10 +89,11 @@ public class DefaultExecutionEngineTest {
 
         // When
         engineUnderTest.execute(stepDefinition, scenarioExecution);
-        getInstance().post(new StopExecutionAction(scenarioExecution.executionId));
         reporter.subscribeOnExecution(scenarioExecution.executionId).blockingLast();
 
         // Then
+        assertThat(scenarioExecution.hasToStop()).isFalse();
+
         Step finalStep = events.get(0).step;
         assertThat(finalStep.type()).isEqualTo("final");
         assertThat(finalStep.definition().name).isEqualTo("Finally action generated for task name");
@@ -130,13 +112,98 @@ public class DefaultExecutionEngineTest {
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("retry", strategyProperties);
         StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null, null, fakeEnvironment);
 
-        ScenarioExecution mockScenarioExecution = mock(ScenarioExecution.class);
+        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
+        scenarioExecution.registerFinallyAction(FinallyAction.Builder.forAction("final", "task name").build());
+
+        List<BeginStepExecutionEvent> events = new ArrayList<>();
+        getInstance().registerOnExecutionId(BeginStepExecutionEvent.class, scenarioExecution.executionId, e -> events.add((BeginStepExecutionEvent) e));
 
         // When
-        Long executionId = engineUnderTest.execute(stepDefinition, mockScenarioExecution);
+        Long executionId = engineUnderTest.execute(stepDefinition, scenarioExecution);
         reporter.subscribeOnExecution(executionId).blockingLast();
 
         // Then
-        verify(mockScenarioExecution, times(1)).executeFinallyActions(any(),any(), any());
+        assertThat(scenarioExecution.hasToStop()).isFalse();
+
+        Step finalStep = events.get(0).step;
+        assertThat(finalStep.type()).isEqualTo("final");
+        assertThat(finalStep.definition().name).isEqualTo("Finally action generated for task name");
+    }
+
+    @Test
+    public void finally_actions_are_executed_in_reverse_order() {
+        // Given
+        Reporter reporter = new Reporter();
+        DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, taskExecutor);
+
+        StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
+        when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy);
+        when(strategy.execute(any(), any(), any(), any())).thenReturn(Status.SUCCESS);
+
+        StepDefinition stepDefinition = new StepDefinition("name", null, "type", null, null, null, null, null, fakeEnvironment);
+
+        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
+
+        Map<String, Object> entries1 = Map.of("key1", "value1");
+        Map<String, Object> entries2 = Map.of("key2", "value2");
+        FinallyAction first = FinallyAction.Builder.forAction("context-put", "first").withInput("entries", entries1).build();
+        FinallyAction second = FinallyAction.Builder.forAction("failure", "second").build();
+        FinallyAction third = FinallyAction.Builder.forAction("context-put", "third").withInput("entries", entries2).build();
+        scenarioExecution.registerFinallyAction(first);
+        scenarioExecution.registerFinallyAction(second);
+        scenarioExecution.registerFinallyAction(third);
+
+        List<BeginStepExecutionEvent> events = new ArrayList<>();
+        getInstance().registerOnExecutionId(BeginStepExecutionEvent.class, scenarioExecution.executionId, e -> events.add((BeginStepExecutionEvent) e));
+
+        // When
+        engineUnderTest.execute(stepDefinition, scenarioExecution);
+        reporter.subscribeOnExecution(scenarioExecution.executionId).blockingLast();
+
+        // Then
+        //Test order is reversed
+        Step thirdStep = events.get(0).step;
+        Step secondStep = events.get(1).step;
+        Step firstStep = events.get(2).step;
+
+        assertThat(thirdStep.type()).isEqualTo("context-put");
+        Map<String, Object> e1 = (Map<String, Object>) thirdStep.definition().inputs.get("entries");
+        assertThat(e1).containsAllEntriesOf(entries2);
+
+        assertThat(secondStep.type()).isEqualTo("failure");
+
+        assertThat(firstStep.type()).isEqualTo("context-put");
+        Map<String, Object> e2 = (Map<String, Object>) firstStep.definition().inputs.get("entries");
+        assertThat(e2).containsAllEntriesOf(entries1);
+    }
+
+    @Test
+    public void should_add_finally_actions_to_root_step() {
+        Reporter reporter = new Reporter();
+        DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, taskExecutor);
+
+        StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
+        when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy);
+        when(strategy.execute(any(), any(), any(), any())).thenReturn(Status.SUCCESS);
+
+        StepDefinition stepDefinition = new StepDefinition("name", null, "type", null, null, null, null, null, fakeEnvironment);
+
+        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
+
+        FinallyAction finallyAction = FinallyAction.Builder.forAction("final", "name").build();
+        scenarioExecution.registerFinallyAction(finallyAction);
+
+        AtomicReference<EndScenarioExecutionEvent> endEvent = new AtomicReference<>();
+        getInstance().registerOnExecutionId(EndScenarioExecutionEvent.class, scenarioExecution.executionId, e -> endEvent.set((EndScenarioExecutionEvent) e));
+
+        // When
+        engineUnderTest.execute(stepDefinition, scenarioExecution);
+        reporter.subscribeOnExecution(scenarioExecution.executionId).blockingLast();
+        await().untilAtomic(endEvent, notNullValue());
+
+        // Then
+        Step rootStep = endEvent.get().step;
+        assertThat(rootStep.subSteps().size()).isEqualTo(1);
+        assertThat(rootStep.subSteps().get(0).definition().name).isEqualTo("Finally action generated for name");
     }
 }

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapperTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapperTest.java
@@ -8,6 +8,7 @@ import com.chutneytesting.engine.domain.environment.TargetImpl;
 import com.chutneytesting.engine.domain.execution.StepDefinition;
 import com.chutneytesting.task.spi.FinallyAction;
 import com.chutneytesting.task.spi.injectable.Target;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class FinallyActionMapperTest {
@@ -23,6 +24,8 @@ public class FinallyActionMapperTest {
                 .withUrl("proto://host:12345")
                 .build())
             .withInput("test-input", "test")
+            .withStrategyType("strategyType")
+            .withStrategyProperties(Map.of("param", "value"))
             .build();
 
         StepDefinition stepDefinition = mapper.toStepDefinition(finallyAction);
@@ -34,7 +37,11 @@ public class FinallyActionMapperTest {
         Target targetCopy = stepDefinition.getTarget().get();
         assertThat(targetCopy.name()).isEqualTo("test-target");
         assertThat(targetCopy.url()).isEqualTo("proto://host:12345");
-        assertThat(((SecurityInfoImpl)targetCopy.security()).hasCredential()).isFalse();
+        assertThat(((SecurityInfoImpl) targetCopy.security()).hasCredential()).isFalse();
         assertThat(targetCopy.security().credential()).isEmpty();
+        assertThat(stepDefinition.getStrategy()).hasValueSatisfying(s -> {
+            assertThat(s.type).isEqualTo("strategyType");
+            assertThat(s.strategyProperties).contains(entry("param", "value"));
+        });
     }
 }

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapperTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapperTest.java
@@ -24,6 +24,7 @@ public class FinallyActionMapperTest {
                 .withUrl("proto://host:12345")
                 .build())
             .withInput("test-input", "test")
+            .withValidation("test-validation", true)
             .withStrategyType("strategyType")
             .withStrategyProperties(Map.of("param", "value"))
             .build();
@@ -31,8 +32,9 @@ public class FinallyActionMapperTest {
         StepDefinition stepDefinition = mapper.toStepDefinition(finallyAction);
 
         assertThat(stepDefinition.type).isEqualTo("test-action");
-        assertThat(stepDefinition.name).isEqualTo("Finally action generated for task name");
+        assertThat(stepDefinition.name).isEqualTo("task name");
         assertThat(stepDefinition.inputs).containsOnly(entry("test-input", "test"));
+        assertThat(stepDefinition.validations).containsOnly(entry("test-validation", true));
         assertThat(stepDefinition.getTarget()).isPresent();
         Target targetCopy = stepDefinition.getTarget().get();
         assertThat(targetCopy.name()).isEqualTo("test-target");

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/ScenarioExecutionTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/ScenarioExecutionTest.java
@@ -1,33 +1,12 @@
 package com.chutneytesting.engine.domain.execution.engine;
 
 import static com.chutneytesting.engine.domain.execution.RxBus.getInstance;
-import static com.chutneytesting.tools.WaitUtils.awaitDuring;
-import static com.google.common.collect.Lists.newArrayList;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 
 import com.chutneytesting.engine.domain.execution.ScenarioExecution;
-import com.chutneytesting.engine.domain.execution.StepDefinition;
-import com.chutneytesting.engine.domain.execution.TestTaskTemplateLoader;
 import com.chutneytesting.engine.domain.execution.action.PauseExecutionAction;
 import com.chutneytesting.engine.domain.execution.action.ResumeExecutionAction;
 import com.chutneytesting.engine.domain.execution.action.StopExecutionAction;
-import com.chutneytesting.engine.domain.execution.engine.evaluation.StepDataEvaluator;
-import com.chutneytesting.engine.domain.execution.engine.scenario.ScenarioContextImpl;
-import com.chutneytesting.engine.domain.execution.engine.step.Step;
-import com.chutneytesting.engine.domain.execution.evaluation.SpelFunctions;
-import com.chutneytesting.engine.domain.execution.event.BeginStepExecutionEvent;
-import com.chutneytesting.task.domain.TaskTemplateRegistry;
-import com.chutneytesting.task.spi.FinallyAction;
-import com.chutneytesting.task.spi.FinallyAction.Builder;
-import com.google.common.collect.Maps;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class ScenarioExecutionTest {
@@ -55,118 +34,6 @@ public class ScenarioExecutionTest {
         assertThat(scenarioExecution.hasToPause()).isFalse();
         assertThat(scenarioExecution.hasToStop()).isTrue();
 
-    }
-
-    @Test
-    public void finally_actions_are_executed_in_reverse_order() {
-        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
-
-        TaskTemplateRegistry taskTemplateRegistry = TestTaskTemplateLoader.buildRegistry();
-
-        HashMap<Object, Object> entries1 = Maps.newHashMap();
-        entries1.put("key1", "value1");
-        HashMap<Object, Object> entries2 = Maps.newHashMap();
-        entries2.put("key2", "value2");
-        FinallyAction first = Builder.forAction("context-put", "first").withInput("entries", entries1).build();
-        FinallyAction second = Builder.forAction("failure", "second").build();
-        FinallyAction third = Builder.forAction("context-put", "third").withInput("entries", entries2).build();
-        scenarioExecution.registerFinallyAction(first);
-        scenarioExecution.registerFinallyAction(second);
-        scenarioExecution.registerFinallyAction(third);
-
-        List<BeginStepExecutionEvent> events = new ArrayList<>();
-
-        getInstance().registerOnExecutionId(BeginStepExecutionEvent.class, scenarioExecution.executionId, e -> events.add((BeginStepExecutionEvent) e));
-
-        Step rootStep = createRootStep();
-        scenarioExecution.executeFinallyActions(rootStep, new ScenarioContextImpl(), fa -> new Step(
-            new StepDataEvaluator(new SpelFunctions()),
-            new FinallyActionMapper().toStepDefinition(fa),
-            Optional.empty(),
-            new DefaultStepExecutor(taskTemplateRegistry),
-            Collections.emptyList()
-        ));
-
-        awaitDuring(100, MILLISECONDS);
-
-        //Test order is reversed
-        Step thirdStep = events.get(0).step;
-        Step secondStep = events.get(1).step;
-        Step firstStep = events.get(2).step;
-
-        assertThat(thirdStep.type()).isEqualTo("context-put");
-        Map<String, Object> e1 = (Map<String, Object>) thirdStep.definition().inputs.get("entries");
-        assertThat(e1).containsOnly(entry("key2", "value2"));
-
-        assertThat(secondStep.type()).isEqualTo("failure");
-
-        assertThat(firstStep.type()).isEqualTo("context-put");
-        Map<String, Object> e2 = (Map<String, Object>) firstStep.definition().inputs.get("entries");
-        assertThat(e2).containsOnly(entry("key1", "value1"));
-
-    }
-
-    @Test
-    public void should_execute_finally_actions_on_scenario_stop() {
-        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
-
-        TaskTemplateRegistry taskTemplateRegistry = TestTaskTemplateLoader.buildRegistry();
-
-        FinallyAction finallyAction = Builder.forAction("final", "name").build();
-        scenarioExecution.registerFinallyAction(finallyAction);
-
-        List<BeginStepExecutionEvent> events = new ArrayList<>();
-        getInstance().register(BeginStepExecutionEvent.class, events::add);
-
-        Step rootStep = createRootStep();
-
-        // When
-        getInstance().post(new StopExecutionAction(scenarioExecution.executionId));
-        scenarioExecution.executeFinallyActions(rootStep, new ScenarioContextImpl(), fa -> new Step(
-            new StepDataEvaluator(new SpelFunctions()),
-            new FinallyActionMapper().toStepDefinition(fa),
-            Optional.empty(),
-            new DefaultStepExecutor(taskTemplateRegistry),
-            Collections.emptyList()
-        ));
-
-        // Then
-        Step finalStep = events.get(0).step;
-        assertThat(finalStep.type()).isEqualTo("final");
-    }
-
-    @Test
-    public void should_add_finally_actions_to_root_step() {
-        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
-
-        TaskTemplateRegistry taskTemplateRegistry = TestTaskTemplateLoader.buildRegistry();
-
-        FinallyAction finallyAction = Builder.forAction("final", "name").build();
-        scenarioExecution.registerFinallyAction(finallyAction);
-
-        List<BeginStepExecutionEvent> events = new ArrayList<>();
-        getInstance().register(BeginStepExecutionEvent.class, events::add);
-
-        Step rootStep = createRootStep();
-
-        // When
-        getInstance().post(new StopExecutionAction(scenarioExecution.executionId));
-        scenarioExecution.executeFinallyActions(rootStep, new ScenarioContextImpl(), fa -> new Step(
-            new StepDataEvaluator(new SpelFunctions()),
-            new FinallyActionMapper().toStepDefinition(fa),
-            Optional.empty(),
-            new DefaultStepExecutor(taskTemplateRegistry),
-            Collections.emptyList()
-        ));
-
-        // Then
-        assertThat(rootStep.subSteps().size()).isEqualTo(1);
-        assertThat(rootStep.subSteps().get(0).definition().name).isEqualTo("Finally action generated for name");
-    }
-
-    private Step createRootStep() {
-        StepDefinition stepDefinition = new StepDefinition("rootStep", null, "type", null, null, null, null, null, null);
-        return new Step(null, stepDefinition, Optional.empty(), null, newArrayList());
     }
 
 }

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/SoftAssertStrategyTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/SoftAssertStrategyTest.java
@@ -4,12 +4,9 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.chutneytesting.engine.domain.execution.ScenarioExecution;
-import com.chutneytesting.engine.domain.execution.engine.scenario.ScenarioContext;
 import com.chutneytesting.engine.domain.execution.engine.step.Step;
 import com.chutneytesting.engine.domain.execution.report.Status;
 import org.junit.jupiter.api.Test;
@@ -21,12 +18,10 @@ public class SoftAssertStrategyTest {
     @Test
     public void should_run_all_substeps_regardless_of_failure_when_using_soft_assert_on_parent_step() {
         // Given
-        ScenarioExecution scenarioExecution = null;
-
         Step failureStep = mock(Step.class);
         when(failureStep.execute(any(), any())).thenReturn(Status.FAILURE);
         Step failureStep2 = mock(Step.class);
-        when(failureStep2.execute(any(), any())).thenReturn(Status.FAILURE);
+        when(failureStep2.execute(any(), any())).thenThrow(new RuntimeException());
         Step successStep = mock(Step.class);
         when(successStep.execute(any(), any())).thenReturn(Status.SUCCESS);
 
@@ -34,25 +29,22 @@ public class SoftAssertStrategyTest {
         when(rootStep.subSteps()).thenReturn(newArrayList(failureStep, failureStep2, successStep));
         when(rootStep.isParentStep()).thenReturn(true);
 
-        ScenarioContext scenarioContext = null;
         StepExecutionStrategies strategies = mock(StepExecutionStrategies.class);
         when(strategies.buildStrategyFrom(any())).thenReturn(DefaultStepExecutionStrategy.instance);
 
         // When
-        Status actualStatus = sut.execute(scenarioExecution, rootStep, scenarioContext, strategies);
+        Status actualStatus = sut.execute(null, rootStep, null, strategies);
 
         // Then
-        verify(failureStep, times(1)).execute(any(), any());
-        verify(failureStep2, times(1)).execute(any(), any());
-        verify(successStep, times(1)).execute(any(), any());
+        verify(failureStep).execute(any(), any());
+        verify(failureStep2).execute(any(), any());
+        verify(successStep).execute(any(), any());
         assertThat(actualStatus).isEqualTo(Status.WARN);
     }
 
     @Test
     public void should_run_next_step_when_current_step_fails_with_soft_assert() {
         // Given
-        ScenarioExecution scenarioExecution = null;
-
         Step failureStepWithSoftAssert = mock(Step.class);
         when(failureStepWithSoftAssert.execute(any(), any())).thenReturn(Status.FAILURE);
 
@@ -63,18 +55,17 @@ public class SoftAssertStrategyTest {
         when(rootStep.subSteps()).thenReturn(newArrayList(failureStepWithSoftAssert, nextStep));
         when(rootStep.isParentStep()).thenReturn(true);
 
-        ScenarioContext scenarioContext = null;
         StepExecutionStrategies strategies = mock(StepExecutionStrategies.class);
         when(strategies.buildStrategyFrom(rootStep)).thenReturn(DefaultStepExecutionStrategy.instance);
         when(strategies.buildStrategyFrom(failureStepWithSoftAssert)).thenReturn(sut);
         when(strategies.buildStrategyFrom(nextStep)).thenReturn(DefaultStepExecutionStrategy.instance);
 
         // When
-        DefaultStepExecutionStrategy.instance.execute(scenarioExecution, rootStep, scenarioContext, strategies);
+        DefaultStepExecutionStrategy.instance.execute(null, rootStep, null, strategies);
 
         // Then
-        verify(failureStepWithSoftAssert, times(1)).execute(any(), any());
-        verify(nextStep, times(1)).execute(any(), any());
+        verify(failureStepWithSoftAssert).execute(any(), any());
+        verify(nextStep).execute(any(), any());
     }
 
 }

--- a/engine/src/test/java/com/chutneytesting/engine/domain/report/ReporterTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/report/ReporterTest.java
@@ -110,6 +110,8 @@ public class ReporterTest {
         scenarioExecutionReportObservable.assertValueCount(0);
 
         executeFakeScenarioSuccess();
+
+        scenarioExecutionReportObservable.assertTerminated();
         scenarioExecutionReportObservable.assertValueCount(10);
 
         scenarioExecutionReportObservable.dispose();

--- a/server/src/test/java/blackbox/task/SelfRegisteringFinallyTask.java
+++ b/server/src/test/java/blackbox/task/SelfRegisteringFinallyTask.java
@@ -21,7 +21,7 @@ public class SelfRegisteringFinallyTask implements Task {
 
     @Override
     public TaskExecutionResult execute() {
-        finallyActionRegistry.registerFinallyAction(FinallyAction.Builder.forAction("self-registering-finally", SelfRegisteringFinallyTask.class.getSimpleName()).build());
+        finallyActionRegistry.registerFinallyAction(FinallyAction.Builder.forAction("self-registering-finally", SelfRegisteringFinallyTask.class).build());
         return TaskExecutionResult.ok();
     }
 }

--- a/server/src/test/resources/blackbox/tasks/final.feature
+++ b/server/src/test/resources/blackbox/tasks/final.feature
@@ -17,7 +17,7 @@ Feature: Final task for registering final actions for a testcase
                         "when":{
                             "sentence":"Final task is registered",
                             "implementation":{
-                                "task":"{\n type: final \n inputs: {\n identifier: success \n what-for: Testing final task... \n} \n}"
+                                "task":"{\n type: final \n inputs: {\n type: success \n name: Testing final task... \n} \n}"
                             }
                         },
                         "thens": []
@@ -48,13 +48,13 @@ Feature: Final task for registering final actions for a testcase
             Do json-assert
                 With document ${#report}
                 With expected
-                | $.report.steps[1].name | ... |
+                | $.report.steps[1].name | TearDown |
                 | $.report.steps[2].name | $isNull |
         And The report contains a single final action execution
             Do json-assert
                 With document ${#report}
                 With expected
-                | $.report.steps[1].steps[0].name | Finally action generated for Testing final task... |
+                | $.report.steps[1].steps[0].name | Testing final task... |
                 | $.report.steps[1].steps[0].type | success |
                 | $.report.steps[1].steps[1] | $isNull |
 
@@ -76,20 +76,20 @@ Feature: Final task for registering final actions for a testcase
                                 {
                                     "sentence":"Register an assertion",
                                     "implementation":{
-                                        "task":"{\n type: final \n inputs: {\n identifier: compare \n inputs: {\n actual: aValue \n expected: aValue \n mode: equals \n} \n} \n}"
+                                        "task":"{\n type: final \n inputs: {\n type: compare \n name: An assertion \n inputs: {\n actual: aValue \n expected: aValue \n mode: equals \n} \n} \n}"
                                     }
                                 },
                                 {
                                     "sentence":"Register a fail with retry",
                                     "implementation":{
-                                        "task":"{\n type: final \n inputs: {\n identifier: fail \n strategy-type: retry-with-timeout \n strategy-properties: {\n timeOut: 1500 ms \n retryDelay: 1 s \n} \n} \n}"
+                                        "task":"{\n type: final \n inputs: {\n type: fail \n name: I'm no good \n strategy-type: retry-with-timeout \n strategy-properties: {\n timeOut: 1500 ms \n retryDelay: 1 s \n} \n} \n}"
                                     }
                                 },
                                 {
                                     "sentence":"Register variable in context",
                                     "implementation":{
                                         "target": "CHUTNEY_LOCAL",
-                                        "task":"{\n type: final \n inputs: {\n identifier: context-put \n inputs: {\n entries: {\n myKey: myValue \n} \n} \n} \n}"
+                                        "task":"{\n type: final \n inputs: {\n type: context-put \n name: Put myKey \n inputs: {\n entries: {\n myKey: myValue \n} \n} validations: {\n putOk: \${#myKey == 'myValue'} \n} \n} \n}"
                                     }
                                 }
                             ]
@@ -122,10 +122,10 @@ Feature: Final task for registering final actions for a testcase
             Do json-assert
                 With document ${#report}
                 With expected
-                | $.report.steps[1].steps[0].type | context-put |
+                | $.report.steps[1].steps[0].type | compare |
                 | $.report.steps[1].steps[0].status | SUCCESS |
                 | $.report.steps[1].steps[1].type | fail |
                 | $.report.steps[1].steps[1].status | FAILURE |
                 | $.report.steps[1].steps[1].strategy | retry-with-timeout |
-                | $.report.steps[1].steps[2].type | compare |
+                | $.report.steps[1].steps[2].type | context-put |
                 | $.report.steps[1].steps[2].status | SUCCESS |

--- a/server/src/test/resources/blackbox/tasks/final.feature
+++ b/server/src/test/resources/blackbox/tasks/final.feature
@@ -1,0 +1,131 @@
+# language: en
+
+Feature: Final task for registering final actions for a testcase
+
+    Scenario: Register simple success task
+        Given A simple scenario is saved
+            Do http-post Post scenario to Chutney instance
+                On CHUTNEY_LOCAL
+                With uri /api/scenario/v2
+                With headers
+                | Content-Type | application/json;charset=UTF-8 |
+                With body
+                """
+                {
+                    "title":"Final task success",
+                    "scenario":{
+                        "when":{
+                            "sentence":"Final task is registered",
+                            "implementation":{
+                                "task":"{\n type: final \n inputs: {\n identifier: success \n what-for: Testing final task... \n} \n}"
+                            }
+                        },
+                        "thens": []
+                    }
+                }
+                """
+                Take scenarioId ${#body}
+            Do compare Assert HTTP status is 200
+                With actual ${T(Integer).toString(#status)}
+                With expected 200
+                With mode equals
+        When Last saved scenario is executed
+            Do http-post Post scenario execution to Chutney instance
+                On CHUTNEY_LOCAL
+                With uri /api/ui/scenario/execution/v1/${#scenarioId}/ENV
+                With timeout 5 s
+                Take report ${#body}
+            Do compare Assert HTTP status is 200
+                With actual ${T(Integer).toString(#status)}
+                With expected 200
+                With mode equals
+        Then The report status is SUCCESS
+            Do compare
+                With actual ${#json(#report, "$.report.status")}
+                With expected SUCCESS
+                With mode equals
+        And The report contains a single node for final actions
+            Do json-assert
+                With document ${#report}
+                With expected
+                | $.report.steps[1].name | ... |
+                | $.report.steps[2].name | $isNull |
+        And The report contains a single final action execution
+            Do json-assert
+                With document ${#report}
+                With expected
+                | $.report.steps[1].steps[0].name | Finally action generated for Testing final task... |
+                | $.report.steps[1].steps[0].type | success |
+                | $.report.steps[1].steps[1] | $isNull |
+
+    Scenario: Register multiple tasks with one complex, i.e. with inputs and strategy
+        Given A complex scenario is saved
+            Do http-post Post scenario to Chutney instance
+                On CHUTNEY_LOCAL
+                With uri /api/scenario/v2
+                With headers
+                | Content-Type | application/json;charset=UTF-8 |
+                With body
+                """
+                {
+                    "title":"Final task success",
+                    "scenario":{
+                        "when":{
+                            "sentence":"Final tasks are registered",
+                            "subSteps":[
+                                {
+                                    "sentence":"Register an assertion",
+                                    "implementation":{
+                                        "task":"{\n type: final \n inputs: {\n identifier: compare \n inputs: {\n actual: aValue \n expected: aValue \n mode: equals \n} \n} \n}"
+                                    }
+                                },
+                                {
+                                    "sentence":"Register a fail with retry",
+                                    "implementation":{
+                                        "task":"{\n type: final \n inputs: {\n identifier: fail \n strategy-type: retry-with-timeout \n strategy-properties: {\n timeOut: 1500 ms \n retryDelay: 1 s \n} \n} \n}"
+                                    }
+                                },
+                                {
+                                    "sentence":"Register variable in context",
+                                    "implementation":{
+                                        "target": "CHUTNEY_LOCAL",
+                                        "task":"{\n type: final \n inputs: {\n identifier: context-put \n inputs: {\n entries: {\n myKey: myValue \n} \n} \n} \n}"
+                                    }
+                                }
+                            ]
+                        },
+                        "thens": []
+                    }
+                }
+                """
+                Take scenarioId ${#body}
+            Do compare Assert HTTP status is 200
+                With actual ${T(Integer).toString(#status)}
+                With expected 200
+                With mode equals
+        When Last saved scenario is executed
+            Do http-post Post scenario execution to Chutney instance
+                On CHUTNEY_LOCAL
+                With uri /api/ui/scenario/execution/v1/${#scenarioId}/ENV
+                With timeout 5 s
+                Take report ${#body}
+            Do compare Assert HTTP status is 200
+                With actual ${T(Integer).toString(#status)}
+                With expected 200
+                With mode equals
+        Then The report status is FAILURE
+            Do compare
+                With actual ${#json(#report, "$.report.status")}
+                With expected FAILURE
+                With mode equals
+        And The report contains the executions (in declaration reverse order) of all the final tasks action
+            Do json-assert
+                With document ${#report}
+                With expected
+                | $.report.steps[1].steps[0].type | context-put |
+                | $.report.steps[1].steps[0].status | SUCCESS |
+                | $.report.steps[1].steps[1].type | fail |
+                | $.report.steps[1].steps[1].status | FAILURE |
+                | $.report.steps[1].steps[1].strategy | retry-with-timeout |
+                | $.report.steps[1].steps[2].type | compare |
+                | $.report.steps[1].steps[2].status | SUCCESS |

--- a/task-impl/src/main/java/com/chutneytesting/task/amqp/QpidServerStartTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/amqp/QpidServerStartTask.java
@@ -68,7 +68,7 @@ public class QpidServerStartTask implements Task {
     private void createQuitFinallyAction(SystemLauncher systemLauncher) {
         finallyActionRegistry.registerFinallyAction(
             FinallyAction.Builder
-                .forAction("qpid-server-stop", QpidServerStartTask.class.getSimpleName())
+                .forAction("qpid-server-stop", QpidServerStartTask.class)
                 .withInput("qpid-launcher", systemLauncher)
                 .build()
         );

--- a/task-impl/src/main/java/com/chutneytesting/task/context/FinalTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/context/FinalTask.java
@@ -1,0 +1,61 @@
+package com.chutneytesting.task.context;
+
+import static com.chutneytesting.task.spi.TaskExecutionResult.ok;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+
+import com.chutneytesting.task.spi.FinallyAction;
+import com.chutneytesting.task.spi.Task;
+import com.chutneytesting.task.spi.TaskExecutionResult;
+import com.chutneytesting.task.spi.injectable.FinallyActionRegistry;
+import com.chutneytesting.task.spi.injectable.Input;
+import com.chutneytesting.task.spi.injectable.Logger;
+import com.chutneytesting.task.spi.injectable.Target;
+import java.util.Map;
+
+public class FinalTask implements Task {
+
+    private final Logger logger;
+    private final FinallyActionRegistry finallyActionRegistry;
+    private final String taskIdentifier;
+    private final String whatFor;
+    private final Target target;
+    private final Map<String, Object> inputs;
+    private final String strategyType;
+    private final Map<String, Object> strategyProperties;
+
+    public FinalTask(Logger logger,
+                     FinallyActionRegistry finallyActionRegistry,
+                     @Input("identifier") String taskIdentifier,
+                     @Input("what-for") String whatFor,
+                     Target target,
+                     @Input("inputs") Map<String, Object> inputs,
+                     @Input("strategy-type") String strategyType,
+                     @Input("strategy-properties") Map<String, Object> strategyProperties
+    ) {
+        this.logger = logger;
+        this.finallyActionRegistry = finallyActionRegistry;
+        this.taskIdentifier = requireNonNull(taskIdentifier, "identifier is mandatory");
+        this.whatFor = ofNullable(whatFor).orElse(FinalTask.class.getSimpleName());
+        this.target = target;
+        this.inputs = inputs;
+        this.strategyType = strategyType;
+        this.strategyProperties = strategyProperties;
+    }
+
+    @Override
+    public TaskExecutionResult execute() {
+        FinallyAction.Builder finallyActionBuilder = FinallyAction.Builder.forAction(taskIdentifier, whatFor);
+
+        ofNullable(target).ifPresent(finallyActionBuilder::withTarget);
+        ofNullable(inputs).map(Map::entrySet).ifPresent(entries -> entries.forEach(e -> finallyActionBuilder.withInput(e.getKey(), e.getValue())));
+        ofNullable(strategyType).ifPresent(st -> {
+            finallyActionBuilder.withStrategyType(st);
+            ofNullable(strategyProperties).ifPresent(finallyActionBuilder::withStrategyProperties);
+        });
+
+        finallyActionRegistry.registerFinallyAction(finallyActionBuilder.build());
+        logger.info(taskIdentifier + " as finally action registered");
+        return ok();
+    }
+}

--- a/task-impl/src/main/java/com/chutneytesting/task/http/HttpsServerStartTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/http/HttpsServerStartTask.java
@@ -83,7 +83,7 @@ public class HttpsServerStartTask implements Task {
     private void createQuitFinallyAction(WireMockServer httpsServer) {
         finallyActionRegistry.registerFinallyAction(
             FinallyAction.Builder
-                .forAction("https-server-stop", HttpsServerStartTask.class.getSimpleName())
+                .forAction("https-server-stop", HttpsServerStartTask.class)
                 .withInput("https-server", httpsServer)
                 .build()
         );

--- a/task-impl/src/main/java/com/chutneytesting/task/jms/JmsBrokerStartTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/jms/JmsBrokerStartTask.java
@@ -54,7 +54,7 @@ public class JmsBrokerStartTask implements Task {
     private void createQuitFinallyAction(BrokerService brokerService) {
         finallyActionRegistry.registerFinallyAction(
             FinallyAction.Builder
-                .forAction("jms-broker-stop", JmsBrokerStartTask.class.getSimpleName())
+                .forAction("jms-broker-stop", JmsBrokerStartTask.class)
                 .withInput("jms-broker-service", brokerService)
                 .build()
         );

--- a/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaBrokerStartTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaBrokerStartTask.java
@@ -68,7 +68,7 @@ public class KafkaBrokerStartTask implements Task {
     private void createQuitFinallyAction(EmbeddedKafkaBroker broker) {
         finallyActionRegistry.registerFinallyAction(
             FinallyAction.Builder
-                .forAction("kafka-broker-stop", KafkaBrokerStartTask.class.getSimpleName())
+                .forAction("kafka-broker-stop", KafkaBrokerStartTask.class)
                 .withInput("broker", broker)
                 .build()
         );

--- a/task-impl/src/main/java/com/chutneytesting/task/selenium/SeleniumDriverInitTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/selenium/SeleniumDriverInitTask.java
@@ -49,7 +49,7 @@ public class SeleniumDriverInitTask implements Task {
 
         finallyActionRegistry.registerFinallyAction(
             FinallyAction.Builder
-                .forAction("selenium-quit", SeleniumDriverInitTask.class.getSimpleName())
+                .forAction("selenium-quit", SeleniumDriverInitTask.class)
                 .withInput("web-driver", webDriver)
                 .build()
         );

--- a/task-impl/src/main/java/com/chutneytesting/task/selenium/SeleniumRemoteDriverInitTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/selenium/SeleniumRemoteDriverInitTask.java
@@ -69,7 +69,7 @@ public class SeleniumRemoteDriverInitTask implements Task {
     private void createQuitFinallyAction(WebDriver webDriver) {
         finallyActionRegistry.registerFinallyAction(
             FinallyAction.Builder
-                .forAction("selenium-quit", SeleniumRemoteDriverInitTask.class.getSimpleName())
+                .forAction("selenium-quit", SeleniumRemoteDriverInitTask.class)
                 .withInput("web-driver", webDriver)
                 .build()
         );

--- a/task-impl/src/main/java/com/chutneytesting/task/ssh/SshServerStartTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/ssh/SshServerStartTask.java
@@ -109,7 +109,7 @@ public class SshServerStartTask implements Task {
     private void createQuitFinallyAction(SshServerMock sshServer) {
         finallyActionRegistry.registerFinallyAction(
             FinallyAction.Builder
-                .forAction("ssh-server-stop", SshServerStartTask.class.getSimpleName())
+                .forAction("ssh-server-stop", SshServerStartTask.class)
                 .withInput("ssh-server", sshServer)
                 .build()
         );

--- a/task-impl/src/main/resources/META-INF/extension/chutney.tasks
+++ b/task-impl/src/main/resources/META-INF/extension/chutney.tasks
@@ -3,6 +3,7 @@ com.chutneytesting.task.context.FailTask
 com.chutneytesting.task.context.DebugTask
 com.chutneytesting.task.context.SleepTask
 com.chutneytesting.task.context.ContextPutTask
+com.chutneytesting.task.context.FinalTask
 
 com.chutneytesting.task.groovy.GroovyTask
 

--- a/task-impl/src/test/java/com/chutneytesting/task/amqp/AmqpTasksTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/amqp/AmqpTasksTest.java
@@ -3,20 +3,20 @@ package com.chutneytesting.task.amqp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import com.chutneytesting.task.TestFinallyActionRegistry;
+import com.chutneytesting.task.TestLogger;
+import com.chutneytesting.task.TestTarget;
+import com.chutneytesting.task.spi.FinallyAction;
+import com.chutneytesting.task.spi.Task;
+import com.chutneytesting.task.spi.TaskExecutionResult;
+import com.chutneytesting.task.spi.TaskExecutionResult.Status;
+import com.chutneytesting.task.spi.injectable.Target;
 import com.github.fridujo.rabbitmq.mock.MockConnectionFactory;
 import com.google.common.collect.ImmutableList;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.LongString;
 import com.rabbitmq.client.impl.LongStringHelper;
-import com.chutneytesting.task.spi.FinallyAction;
-import com.chutneytesting.task.spi.Task;
-import com.chutneytesting.task.spi.TaskExecutionResult;
-import com.chutneytesting.task.spi.TaskExecutionResult.Status;
-import com.chutneytesting.task.spi.injectable.Target;
-import com.chutneytesting.task.TestFinallyActionRegistry;
-import com.chutneytesting.task.TestLogger;
-import com.chutneytesting.task.TestTarget;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -183,8 +183,8 @@ public class AmqpTasksTest {
         TaskExecutionResult amqpCreateBoundTemporaryQueueResult = amqpCreateBoundTemporaryQueueTask.execute();
         assertThat(amqpCreateBoundTemporaryQueueResult.status).isEqualTo(Status.Success);
         assertThat(finallyActionRegistry.finallyActions)
-            .extracting(FinallyAction::actionIdentifier)
-            .containsExactly("amqp-delete-queue", "amqp-unbind-queue");
+            .extracting(FinallyAction::type)
+            .containsExactly("amqp-unbind-queue", "amqp-delete-queue");
 
         return (String) amqpCreateBoundTemporaryQueueResult.outputs.get("queueName");
     }

--- a/task-impl/src/test/java/com/chutneytesting/task/amqp/QpidServerStartTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/amqp/QpidServerStartTaskTest.java
@@ -28,7 +28,7 @@ class QpidServerStartTaskTest {
             .hasSize(1)
             .hasOnlyElementsOfType(FinallyAction.class);
 
-        assertThat(finallyActionRegistry.finallyActions.get(0).actionIdentifier())
+        assertThat(finallyActionRegistry.finallyActions.get(0).type())
             .isEqualTo("qpid-server-stop");
     }
 

--- a/task-impl/src/test/java/com/chutneytesting/task/context/FinalTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/context/FinalTaskTest.java
@@ -1,7 +1,7 @@
 package com.chutneytesting.task.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.chutneytesting.task.TestLogger;
 import com.chutneytesting.task.TestTarget;
@@ -15,59 +15,70 @@ import org.junit.jupiter.api.Test;
 
 public class FinalTaskTest {
 
-    private FinalTask sut;
+    @Test
+    void task_type_is_mandatory() {
+        assertThatThrownBy(
+            () -> new FinalTask(new TestLogger(), null, null, null, null, null, null, null, null)
+        )
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("type is mandatory");
+    }
 
     @Test
-    void task_identifier_is_mandatory() {
-        assertThrows(
-            NullPointerException.class,
-            () -> new FinalTask(new TestLogger(), null, null, null, null, null, null, null)
-        );
+    void name_is_mandatory() {
+        assertThatThrownBy(
+            () -> new FinalTask(new TestLogger(), null, "", null, null, null, null, null, null)
+        )
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("name is mandatory");
     }
 
     @Test
     void should_register_simple_finally_action() {
         TestLogger logger = new TestLogger();
         List<FinallyAction> registeredFinallyActions = new ArrayList<>();
-        sut = new FinalTask(logger, registeredFinallyActions::add, "debug", null, null, null, null, null);
+        FinalTask sut = new FinalTask(logger, registeredFinallyActions::add, "debug", "a finally action", null, null, null, null, null);
 
         TaskExecutionResult result = sut.execute();
 
         assertThat(result.status).isEqualTo(TaskExecutionResult.Status.Success);
         assertThat(result.outputs).isEmpty();
 
-        assertThat(logger.info).containsExactly("debug as finally action registered");
+        assertThat(logger.info).containsExactly("a finally action (debug) as finally action registered");
         assertThat(logger.errors).isEmpty();
 
         assertThat(registeredFinallyActions).hasSize(1);
         FinallyAction finallyAction = registeredFinallyActions.get(0);
-        assertThat(finallyAction.originalTask()).isEqualTo(FinalTask.class.getSimpleName());
-        assertThat(finallyAction.actionIdentifier()).isEqualTo("debug");
+        assertThat(finallyAction.name()).isEqualTo("a finally action");
+        assertThat(finallyAction.type()).isEqualTo("debug");
         assertThat(finallyAction.target()).isEmpty();
         assertThat(finallyAction.inputs()).isEmpty();
+        assertThat(finallyAction.validations()).isEmpty();
         assertThat(finallyAction.strategyType()).isEmpty();
         assertThat(finallyAction.strategyProperties()).isEmpty();
     }
 
     @Test
-    void should_register_task_with_inputs_and_strategy_finally_action() {
+    void should_register_task_with_inputs_and_validations_and_strategy_finally_action() {
         TestLogger logger = new TestLogger();
         List<FinallyAction> registeredFinallyActions = new ArrayList<>();
         Target target = TestTarget.TestTargetBuilder.builder().withTargetId("target name").withUrl("url").build();
 
-        Map<String, Object> inputs = Map.of("k", "v", "kk", new Object());
+        Map<String, Object> inputs = Map.of("input 1", "value 1", "input 2", new Object());
+        Map<String, Object> validations = Map.of("validation 1", true, "validation 2", new Object());
         String strategyType = "retry";
         Map<String, Object> strategyProperties = Map.of("timeout", "1 s", "delay", new Object());
-        sut = new FinalTask(logger, registeredFinallyActions::add, "complex task", "testing ??", target, inputs, strategyType, strategyProperties);
+        FinalTask sut = new FinalTask(logger, registeredFinallyActions::add, "complex task", "testing ??", target, inputs, validations, strategyType, strategyProperties);
 
         sut.execute();
 
         assertThat(registeredFinallyActions).hasSize(1);
         FinallyAction finallyAction = registeredFinallyActions.get(0);
-        assertThat(finallyAction.originalTask()).isEqualTo("testing ??");
-        assertThat(finallyAction.actionIdentifier()).isEqualTo("complex task");
+        assertThat(finallyAction.name()).isEqualTo("testing ??");
+        assertThat(finallyAction.type()).isEqualTo("complex task");
         assertThat(finallyAction.target()).contains(target);
         assertThat(finallyAction.inputs()).containsAllEntriesOf(inputs);
+        assertThat(finallyAction.validations()).containsAllEntriesOf(validations);
         assertThat(finallyAction.strategyType()).contains(strategyType);
         assertThat(finallyAction.strategyProperties()).containsSame(strategyProperties);
     }

--- a/task-impl/src/test/java/com/chutneytesting/task/context/FinalTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/context/FinalTaskTest.java
@@ -1,0 +1,74 @@
+package com.chutneytesting.task.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.chutneytesting.task.TestLogger;
+import com.chutneytesting.task.TestTarget;
+import com.chutneytesting.task.spi.FinallyAction;
+import com.chutneytesting.task.spi.TaskExecutionResult;
+import com.chutneytesting.task.spi.injectable.Target;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class FinalTaskTest {
+
+    private FinalTask sut;
+
+    @Test
+    void task_identifier_is_mandatory() {
+        assertThrows(
+            NullPointerException.class,
+            () -> new FinalTask(new TestLogger(), null, null, null, null, null, null, null)
+        );
+    }
+
+    @Test
+    void should_register_simple_finally_action() {
+        TestLogger logger = new TestLogger();
+        List<FinallyAction> registeredFinallyActions = new ArrayList<>();
+        sut = new FinalTask(logger, registeredFinallyActions::add, "debug", null, null, null, null, null);
+
+        TaskExecutionResult result = sut.execute();
+
+        assertThat(result.status).isEqualTo(TaskExecutionResult.Status.Success);
+        assertThat(result.outputs).isEmpty();
+
+        assertThat(logger.info).containsExactly("debug as finally action registered");
+        assertThat(logger.errors).isEmpty();
+
+        assertThat(registeredFinallyActions).hasSize(1);
+        FinallyAction finallyAction = registeredFinallyActions.get(0);
+        assertThat(finallyAction.originalTask()).isEqualTo(FinalTask.class.getSimpleName());
+        assertThat(finallyAction.actionIdentifier()).isEqualTo("debug");
+        assertThat(finallyAction.target()).isEmpty();
+        assertThat(finallyAction.inputs()).isEmpty();
+        assertThat(finallyAction.strategyType()).isEmpty();
+        assertThat(finallyAction.strategyProperties()).isEmpty();
+    }
+
+    @Test
+    void should_register_task_with_inputs_and_strategy_finally_action() {
+        TestLogger logger = new TestLogger();
+        List<FinallyAction> registeredFinallyActions = new ArrayList<>();
+        Target target = TestTarget.TestTargetBuilder.builder().withTargetId("target name").withUrl("url").build();
+
+        Map<String, Object> inputs = Map.of("k", "v", "kk", new Object());
+        String strategyType = "retry";
+        Map<String, Object> strategyProperties = Map.of("timeout", "1 s", "delay", new Object());
+        sut = new FinalTask(logger, registeredFinallyActions::add, "complex task", "testing ??", target, inputs, strategyType, strategyProperties);
+
+        sut.execute();
+
+        assertThat(registeredFinallyActions).hasSize(1);
+        FinallyAction finallyAction = registeredFinallyActions.get(0);
+        assertThat(finallyAction.originalTask()).isEqualTo("testing ??");
+        assertThat(finallyAction.actionIdentifier()).isEqualTo("complex task");
+        assertThat(finallyAction.target()).contains(target);
+        assertThat(finallyAction.inputs()).containsAllEntriesOf(inputs);
+        assertThat(finallyAction.strategyType()).contains(strategyType);
+        assertThat(finallyAction.strategyProperties()).containsSame(strategyProperties);
+    }
+}

--- a/task-impl/src/test/java/com/chutneytesting/task/selenium/SeleniumDriverInitTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/selenium/SeleniumDriverInitTaskTest.java
@@ -60,7 +60,7 @@ public class SeleniumDriverInitTaskTest {
         // Then
         verify(finallyActionRegistry, times(1)).registerFinallyAction(any());
         FinallyAction quitAction = finallyActionRegistry.finallyActions.get(0);
-        assertThat(quitAction.actionIdentifier()).isEqualTo("selenium-quit");
+        assertThat(quitAction.type()).isEqualTo("selenium-quit");
         assertThat(quitAction.inputs()).containsOnlyKeys("web-driver");
 
         assertThat(result.status).isEqualTo(TaskExecutionResult.Status.Success);

--- a/task-impl/src/test/java/com/chutneytesting/task/selenium/SeleniumRemoteDriverInitTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/selenium/SeleniumRemoteDriverInitTaskTest.java
@@ -70,7 +70,7 @@ public class SeleniumRemoteDriverInitTaskTest {
         // Then
         verify(finallyActionRegistry, times(1)).registerFinallyAction(any());
         FinallyAction quitAction = finallyActionRegistry.finallyActions.get(0);
-        assertThat(quitAction.actionIdentifier()).isEqualTo("selenium-quit");
+        assertThat(quitAction.type()).isEqualTo("selenium-quit");
         assertThat(quitAction.inputs()).containsOnlyKeys("web-driver");
 
         assertThat(result.status).isEqualTo(TaskExecutionResult.Status.Success);

--- a/task-impl/src/test/java/com/chutneytesting/task/ssh/SshServerTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/ssh/SshServerTaskTest.java
@@ -1,7 +1,6 @@
 package com.chutneytesting.task.ssh;
 
 import static java.util.Collections.singletonList;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -29,14 +28,10 @@ class SshServerTaskTest {
     private SshServerMock sshServer;
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws InterruptedException {
         if (sshServer != null) {
             SshServerStopTask sshServerStopTask = new SshServerStopTask(new TestLogger(), sshServer);
             sshServerStopTask.execute();
-
-            await().atMost(2, SECONDS).untilAsserted(() ->
-                assertThat(sshServer.isClosed()).isTrue()
-            );
         }
     }
 
@@ -121,7 +116,7 @@ class SshServerTaskTest {
             assertThat(sshServer.isOpen()).isTrue();
         });
         FinallyAction stopServerTask = finallyActionRegistry.finallyActions.get(0);
-        assertThat(stopServerTask.actionIdentifier()).isEqualTo("ssh-server-stop");
+        assertThat(stopServerTask.type()).isEqualTo("ssh-server-stop");
         assertThat(stopServerTask.inputs().get("ssh-server")).isEqualTo(sshServer);
     }
 

--- a/task-spi/src/main/java/com/chutneytesting/task/spi/FinallyAction.java
+++ b/task-spi/src/main/java/com/chutneytesting/task/spi/FinallyAction.java
@@ -1,65 +1,73 @@
 package com.chutneytesting.task.spi;
 
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Optional.ofNullable;
 
 import com.chutneytesting.task.spi.injectable.Target;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 public class FinallyAction {
-    private final String originalTask;
-    private final String actionIdentifier;
+
+    private final String name;
+    private final String type;
     private final Target target;
     private final Map<String, Object> inputs;
+    private final Map<String, Object> validations;
     private final String strategyType;
     private final Map<String, Object> strategyProperties;
 
     @Deprecated
-    private FinallyAction(String actionIdentifier, Optional<Target> target, Map<String, Object> inputs) {
-        this("", actionIdentifier, target, inputs);
+    private FinallyAction(String type, Optional<Target> target, Map<String, Object> inputs) {
+        this("", type, target, inputs);
     }
 
     @Deprecated
-    private FinallyAction(String originalTask, String actionIdentifier, Optional<Target> target, Map<String, Object> inputs) {
-        this(originalTask, actionIdentifier, target.orElse(null), inputs, null, null);
+    private FinallyAction(String name, String type, Optional<Target> target, Map<String, Object> inputs) {
+        this(name, type, target.orElse(null), inputs, null, null, null);
     }
 
-    private FinallyAction(String originalTask, String actionIdentifier, Target target, Map<String, Object> inputs) {
-        this(originalTask, actionIdentifier, target, inputs, null, null);
+    private FinallyAction(String name, String type, Target target, Map<String, Object> inputs, Map<String, Object> validations) {
+        this(name, type, target, inputs, null, null, null);
     }
 
-    private FinallyAction(String originalTask, String actionIdentifier, Target target, Map<String, Object> inputs, String strategyType, Map<String, Object> strategyProperties) {
-        this.originalTask = originalTask;
-        this.actionIdentifier = actionIdentifier;
+    private FinallyAction(String name, String type, Target target, Map<String, Object> inputs, Map<String, Object> validations, String strategyType, Map<String, Object> strategyProperties) {
+        this.name = name;
+        this.type = type;
         this.target = target;
         this.inputs = inputs;
+        this.validations = validations;
         this.strategyType = strategyType;
         this.strategyProperties = strategyProperties;
     }
 
     public static class Builder {
-        private final String originalTask;
-        private final String identifier;
+        private final String name;
+        private final String type;
         private Target target;
         private final Map<String, Object> inputs = new HashMap<>();
+        private final Map<String, Object> validations = new HashMap<>();
         private String strategyType;
         private Map<String, Object> strategyProperties;
 
         @Deprecated
-        private Builder(String identifier) {
-            this.identifier = identifier;
-            this.originalTask = "";
+        private Builder(String type) {
+            this.type = type;
+            this.name = "";
         }
 
-        private Builder(String identifier, String originalTask) {
-            this.identifier = identifier;
-            this.originalTask = originalTask;
+        private Builder(String type, String name) {
+            this.type = type;
+            this.name = ofNullable(name).orElse("");
         }
 
-        public static Builder forAction(String identifier, String name) {
-            return new Builder(identifier, name);
+        public static Builder forAction(String type, String name) {
+            return new Builder(type, name);
+        }
+
+        public static Builder forAction(String type, Class<?> originalTask) {
+            return new Builder(type, "Finally action generated for " + originalTask.getSimpleName());
         }
 
         public Builder withTarget(Target target) {
@@ -69,6 +77,11 @@ public class FinallyAction {
 
         public Builder withInput(String key, Object value) {
             inputs.put(key, value);
+            return this;
+        }
+
+        public Builder withValidation(String key, Object value) {
+            validations.put(key, value);
             return this;
         }
 
@@ -83,16 +96,26 @@ public class FinallyAction {
         }
 
         public FinallyAction build() {
-            return new FinallyAction(originalTask, identifier, target, Collections.unmodifiableMap(inputs), strategyType, strategyProperties);
+            return new FinallyAction(name, type, target, unmodifiableMap(inputs), unmodifiableMap(validations), strategyType, strategyProperties);
         }
     }
 
+    @Deprecated
     public String originalTask() {
-        return originalTask;
+        return name();
     }
 
+    public String name() {
+        return name;
+    }
+
+    @Deprecated
     public String actionIdentifier() {
-        return actionIdentifier;
+        return type();
+    }
+
+    public String type() {
+        return type;
     }
 
     public Optional<Target> target() {
@@ -101,6 +124,10 @@ public class FinallyAction {
 
     public Map<String, Object> inputs() {
         return inputs;
+    }
+
+    public Map<String, Object> validations() {
+        return validations;
     }
 
     public Optional<String> strategyType() {
@@ -114,7 +141,8 @@ public class FinallyAction {
     @Override
     public String toString() {
         return "FinallyAction{" +
-            "actionIdentifier='" + actionIdentifier + '\'' +
+            "name='" + name + '\'' +
+            ", type=" + type +
             ", targetName=" + target +
             ", inputs=" + inputs +
             ", strategyType=" + strategyType +

--- a/task-spi/src/main/java/com/chutneytesting/task/spi/FinallyAction.java
+++ b/task-spi/src/main/java/com/chutneytesting/task/spi/FinallyAction.java
@@ -1,5 +1,7 @@
 package com.chutneytesting.task.spi;
 
+import static java.util.Optional.ofNullable;
+
 import com.chutneytesting.task.spi.injectable.Target;
 import java.util.Collections;
 import java.util.HashMap;
@@ -9,39 +11,51 @@ import java.util.Optional;
 public class FinallyAction {
     private final String originalTask;
     private final String actionIdentifier;
-    private final Optional<Target> target;
+    private final Target target;
     private final Map<String, Object> inputs;
+    private final String strategyType;
+    private final Map<String, Object> strategyProperties;
 
     @Deprecated
     private FinallyAction(String actionIdentifier, Optional<Target> target, Map<String, Object> inputs) {
-        this.originalTask = "";
-        this.actionIdentifier = actionIdentifier;
-        this.target = target;
-        this.inputs = inputs;
+        this("", actionIdentifier, target, inputs);
     }
 
+    @Deprecated
     private FinallyAction(String originalTask, String actionIdentifier, Optional<Target> target, Map<String, Object> inputs) {
+        this(originalTask, actionIdentifier, target.orElse(null), inputs, null, null);
+    }
+
+    private FinallyAction(String originalTask, String actionIdentifier, Target target, Map<String, Object> inputs) {
+        this(originalTask, actionIdentifier, target, inputs, null, null);
+    }
+
+    private FinallyAction(String originalTask, String actionIdentifier, Target target, Map<String, Object> inputs, String strategyType, Map<String, Object> strategyProperties) {
         this.originalTask = originalTask;
         this.actionIdentifier = actionIdentifier;
         this.target = target;
         this.inputs = inputs;
+        this.strategyType = strategyType;
+        this.strategyProperties = strategyProperties;
     }
 
     public static class Builder {
-        private final String orginalTask;
+        private final String originalTask;
         private final String identifier;
-        private Optional<Target> target = Optional.empty();
+        private Target target;
         private final Map<String, Object> inputs = new HashMap<>();
+        private String strategyType;
+        private Map<String, Object> strategyProperties;
 
         @Deprecated
         private Builder(String identifier) {
             this.identifier = identifier;
-            this.orginalTask = "";
+            this.originalTask = "";
         }
 
-        private Builder(String identifier, String orginalTask) {
+        private Builder(String identifier, String originalTask) {
             this.identifier = identifier;
-            this.orginalTask = orginalTask;
+            this.originalTask = originalTask;
         }
 
         public static Builder forAction(String identifier, String name) {
@@ -49,7 +63,7 @@ public class FinallyAction {
         }
 
         public Builder withTarget(Target target) {
-            this.target = Optional.of(target);
+            this.target = target;
             return this;
         }
 
@@ -58,12 +72,22 @@ public class FinallyAction {
             return this;
         }
 
+        public Builder withStrategyType(String strategyType) {
+            this.strategyType = strategyType;
+            return this;
+        }
+
+        public Builder withStrategyProperties(Map<String, Object> strategyProperties) {
+            this.strategyProperties = strategyProperties;
+            return this;
+        }
+
         public FinallyAction build() {
-            return new FinallyAction(orginalTask, identifier, target, Collections.unmodifiableMap(inputs));
+            return new FinallyAction(originalTask, identifier, target, Collections.unmodifiableMap(inputs), strategyType, strategyProperties);
         }
     }
 
-    public String getOriginalTask() {
+    public String originalTask() {
         return originalTask;
     }
 
@@ -72,11 +96,19 @@ public class FinallyAction {
     }
 
     public Optional<Target> target() {
-        return target;
+        return ofNullable(target);
     }
 
     public Map<String, Object> inputs() {
         return inputs;
+    }
+
+    public Optional<String> strategyType() {
+        return ofNullable(strategyType);
+    }
+
+    public Optional<Map<String, Object>> strategyProperties() {
+        return ofNullable(strategyProperties);
     }
 
     @Override
@@ -85,6 +117,8 @@ public class FinallyAction {
             "actionIdentifier='" + actionIdentifier + '\'' +
             ", targetName=" + target +
             ", inputs=" + inputs +
+            ", strategyType=" + strategyType +
+            ", strategyProperties=" + strategyProperties +
             '}';
     }
 }


### PR DESCRIPTION
#### Issue Number
fixes #534 

#### Describe the changes you've made

Engine executes the finally actions with an eventual strategy in a single root node specific for tear down.
Add a specific task for registering final action.

#### Describe if there is any unusual behaviour of your code

The name of the root node for finally actions is ...

#### Checklist

- [x] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
