### PR TITLE
feat(task-impl): Kafka consume with acknowledge mode as input

### DIFF
--- a/server/src/test/resources/blackbox/tasks/kafka.feature
+++ b/server/src/test/resources/blackbox/tasks/kafka.feature
@@ -151,7 +151,7 @@ Feature: Kafka all Tasks test
                 With expected SUCCESS
                 With mode equals
 
-    Scenario Outline: Kafka basic publish / consume with ackMode <ackMode>
+    Scenario Outline: Kafka basic one publish / two consumes with ackMode <ackMode>
         Given an embedded kafka server with a topic a-topic
             Do kafka-broker-start
                 With topics
@@ -173,7 +173,8 @@ Feature: Kafka all Tasks test
                             "url": "tcp://${#kafkaBroker.getBrokerAddresses()[0]}",
                             "properties": [
                                 { "key": "ackMode", "value": "<ackMode>" },
-                                { "key": "auto.offset.reset", "value": "earliest" }
+                                { "key": "auto.offset.reset", "value": "earliest" },
+                                { "key": "auto.commit.count", "value": "1" }
                             ]
                         }
                     ]
@@ -236,12 +237,20 @@ Feature: Kafka all Tasks test
                 Take report ${#body}
                 Validate httpStatusCode_200 ${#status == 200}
         Then the report status is <reportStatus>
-            Do compare
+            Do compare Global status
                 With actual ${#json(#report, "$.report.status")}
+                With expected <reportStatus>
+                With mode equals
+            Do compare Second consume step status
+                With actual ${#json(#report, "$.report.steps[?(@.name=='Consume from broker the same message again')].status").get(0)}
                 With expected <reportStatus>
                 With mode equals
 
         Examples:
-            | ackMode | reportStatus |
-            | MANUAL  | SUCCESS      |
-            | RECORD  | FAILURE      |
+            | ackMode    | reportStatus |
+            | MANUAL     | SUCCESS      |
+            | RECORD     | FAILURE      |
+            | BATCH      | FAILURE      |
+            | COUNT      | FAILURE      |
+            | COUNT_TIME | FAILURE      |
+            | BATCH      | FAILURE      |

--- a/server/src/test/resources/blackbox/tasks/kafka.feature
+++ b/server/src/test/resources/blackbox/tasks/kafka.feature
@@ -117,7 +117,7 @@ Feature: Kafka all Tasks test
                             {
                                 "sentence":"Consume from broker",
                                 "implementation":{
-                                    "task":"{\n type: kafka-basic-consume \n target: test_kafka \n inputs: {\n topic: a-topic \n group: chutney \n properties: {\n auto.offset.reset: earliest \n} \n} \n outputs: {\n payload : \${#payloads[0]} \n} \n}"
+                                    "task":"{\n type: kafka-basic-consume \n target: test_kafka \n inputs: {\n topic: a-topic \n group: chutney \n ackMode: BATCH \n properties: {\n auto.offset.reset: earliest \n} \n} \n outputs: {\n payload : \${#payloads[0]} \n} \n}"
                                 }
                             },
                             {
@@ -150,3 +150,98 @@ Feature: Kafka all Tasks test
                 With actual ${#json(#report, "$.report.status")}
                 With expected SUCCESS
                 With mode equals
+
+    Scenario Outline: Kafka basic publish / consume with ackMode <ackMode>
+        Given an embedded kafka server with a topic a-topic
+            Do kafka-broker-start
+                With topics
+                | a-topic |
+        And an associated target test_kafka having url in system property spring.embedded.kafka.brokers
+            Do http-post Create environment and target
+                On CHUTNEY_LOCAL
+                With uri /api/v2/environment
+                With headers
+                | Content-Type | application/json;charset=UTF-8 |
+                With body
+                """
+                {
+                    "name": "KAFKA_ENV_<ackMode>",
+                    "description": "",
+                    "targets": [
+                        {
+                            "name": "test_kafka",
+                            "url": "tcp://${#kafkaBroker.getBrokerAddresses()[0]}",
+                            "properties": [
+                                { "key": "ackMode", "value": "<ackMode>" },
+                                { "key": "auto.offset.reset", "value": "earliest" }
+                            ]
+                        }
+                    ]
+                }
+                """
+                Validate httpStatusCode_200 ${#status == 200}
+        And this scenario is saved
+            Do http-post Post scenario to Chutney instance
+                On CHUTNEY_LOCAL
+                With uri /api/scenario/v2
+                With headers
+                | Content-Type | application/json;charset=UTF-8 |
+                With body
+                """
+                {
+                    "title":"kafka client sender",
+                    "scenario":{
+                        "when":{
+                            "sentence":"Publish to broker",
+                            "implementation":{
+                                "task":"{\n type: kafka-basic-publish \n target: test_kafka \n inputs: {\n topic: a-topic \n payload: bodybuilder \n headers: {\n X-API-VERSION: \"1.0\" \n} \n} \n}"
+                            }
+                        },
+                        "thens":[
+                            {
+                                "sentence":"Consume from broker",
+                                "implementation":{
+                                    "task":"{\n type: kafka-basic-consume \n target: test_kafka \n inputs: {\n topic: a-topic \n group: chutney \n} \n outputs: {\n payload : \${#payloads[0]} \n} \n}"
+                                }
+                            },
+                            {
+                                "sentence":"Check payload",
+                                "implementation":{
+                                    "task":"{\n type: string-assert \n inputs: {\n document: \${#payload} \n expected: bodybuilder \n} \n}"
+                                }
+                            },
+                            {
+                                "sentence":"Consume from broker the same message again",
+                                "implementation":{
+                                    "task":"{\n type: kafka-basic-consume \n target: test_kafka \n inputs: {\n topic: a-topic \n group: chutney \n timeout: 3 s \n} \n outputs: {\n payloadBis : \${#payloads[0]} \n} \n}"
+                                }
+                            },
+                            {
+                                "sentence":"Check payload",
+                                "implementation":{
+                                    "task":"{\n type: string-assert \n inputs: {\n document: \${#payloadBis} \n expected: bodybuilder \n} \n}"
+                                }
+                            }
+                        ]
+                    }
+                }
+                """
+                Take scenarioId ${#body}
+                Validate httpStatusCode_200 ${#status == 200}
+        When last saved scenario is executed
+            Do http-post Post scenario execution to Chutney instance
+                On CHUTNEY_LOCAL
+                With uri /api/ui/scenario/execution/v1/${#scenarioId}/KAFKA_ENV_<ackMode>
+                With timeout 5 s
+                Take report ${#body}
+                Validate httpStatusCode_200 ${#status == 200}
+        Then the report status is <reportStatus>
+            Do compare
+                With actual ${#json(#report, "$.report.status")}
+                With expected <reportStatus>
+                With mode equals
+
+        Examples:
+            | ackMode | reportStatus |
+            | MANUAL  | SUCCESS      |
+            | RECORD  | FAILURE      |

--- a/server/src/test/resources/blackbox/tasks/kafka.feature
+++ b/server/src/test/resources/blackbox/tasks/kafka.feature
@@ -165,7 +165,7 @@ Feature: Kafka all Tasks test
                 With body
                 """
                 {
-                    "name": "KAFKA_ENV_<ackMode>",
+                    "name": "KAFKA_ENV_<testEnvName>",
                     "description": "",
                     "targets": [
                         {
@@ -232,7 +232,7 @@ Feature: Kafka all Tasks test
         When last saved scenario is executed
             Do http-post Post scenario execution to Chutney instance
                 On CHUTNEY_LOCAL
-                With uri /api/ui/scenario/execution/v1/${#scenarioId}/KAFKA_ENV_<ackMode>
+                With uri /api/ui/scenario/execution/v1/${#scenarioId}/KAFKA_ENV_<testEnvName>
                 With timeout 5 s
                 Take report ${#body}
                 Validate httpStatusCode_200 ${#status == 200}
@@ -247,10 +247,11 @@ Feature: Kafka all Tasks test
                 With mode equals
 
         Examples:
-            | ackMode    | reportStatus |
-            | MANUAL     | SUCCESS      |
-            | RECORD     | FAILURE      |
-            | BATCH      | FAILURE      |
-            | COUNT      | FAILURE      |
-            | COUNT_TIME | FAILURE      |
-            | BATCH      | FAILURE      |
+            | ackMode          | reportStatus | testEnvName    |
+            | MANUAL           | SUCCESS      | MANUAL         |
+            | MANUAL_IMMEDIATE | SUCCESS      | MANUAL_IMM     |
+            | RECORD           | FAILURE      | RECORD         |
+            | TIME             | FAILURE      | TIME           |
+            | COUNT            | FAILURE      | COUNT          |
+            | COUNT_TIME       | FAILURE      | COUNT_TIME     |
+            | BATCH            | FAILURE      | BATCH          |

--- a/task-impl/src/main/java/com/chutneytesting/task/kafka/ChutneyKafkaProducerFactory.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/kafka/ChutneyKafkaProducerFactory.java
@@ -14,11 +14,11 @@ final class ChutneyKafkaProducerFactory {
 
     private DefaultKafkaProducerFactory<String, String> factory;
 
-    KafkaTemplate<String, String> create(Target target) {
+    KafkaTemplate<String, String> create(Target target, Map<String, String> config) {
 
         Map<String, Object> producerConfig = new HashMap<>();
         producerConfig.put(BOOTSTRAP_SERVERS_CONFIG, resolveBootStrapServerConfig(target));
-        producerConfig.putAll(target.properties());
+        producerConfig.putAll(config);
 
         this.factory = new DefaultKafkaProducerFactory<>(
             producerConfig,

--- a/task-impl/src/main/java/com/chutneytesting/task/kafka/ChutneyKafkaProducerFactory.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/kafka/ChutneyKafkaProducerFactory.java
@@ -1,9 +1,11 @@
 package com.chutneytesting.task.kafka;
 
+import static com.chutneytesting.task.kafka.KafkaClientFactoryHelper.resolveBootStrapServerConfig;
+import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
+
 import com.chutneytesting.task.spi.injectable.Target;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -13,23 +15,17 @@ final class ChutneyKafkaProducerFactory {
     private DefaultKafkaProducerFactory<String, String> factory;
 
     KafkaTemplate<String, String> create(Target target) {
-        Map<String, Object> configProps = new HashMap<>();
 
-        configProps.put(
-            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-            target.url());
+        Map<String, Object> producerConfig = new HashMap<>();
+        producerConfig.put(BOOTSTRAP_SERVERS_CONFIG, resolveBootStrapServerConfig(target));
+        producerConfig.putAll(target.properties());
 
-        configProps.put(
-            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-            StringSerializer.class);
-        configProps.put(
-            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-            StringSerializer.class);
+        this.factory = new DefaultKafkaProducerFactory<>(
+            producerConfig,
+            new StringSerializer(),
+            new StringSerializer());
 
-        target.properties().entrySet().forEach(p -> configProps.put(p.getKey(), p.getValue()));
-
-        this.factory = new DefaultKafkaProducerFactory<>(configProps);
-        return new KafkaTemplate(this.factory, true);
+        return new KafkaTemplate<>(this.factory, true);
     }
 
     void destroy() {

--- a/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTask.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTask.java
@@ -105,6 +105,7 @@ public class KafkaBasicConsumeTask implements Task {
     public List<String> validateInputs() {
         return getErrorsFrom(
             notBlankStringValidation(topic, "topic"),
+            notBlankStringValidation(group, "group"),
             targetValidation(target),
             durationValidation(timeout, "timeout"),
             enumValidation(ContainerProperties.AckMode.class, ackMode, "ackMode")

--- a/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaClientFactoryHelper.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaClientFactoryHelper.java
@@ -1,0 +1,17 @@
+package com.chutneytesting.task.kafka;
+
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG;
+
+import com.chutneytesting.task.spi.injectable.Target;
+import java.net.URI;
+
+final class KafkaClientFactoryHelper {
+
+    static String resolveBootStrapServerConfig(Target target) {
+        return ofNullable(target.properties().get(BOOTSTRAP_SERVERS_CONFIG))
+            .or(() -> of(target.getUrlAsURI()).map(URI::getAuthority))
+            .orElseGet(target::url);
+    }
+}

--- a/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactory.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactory.java
@@ -1,10 +1,10 @@
 package com.chutneytesting.task.kafka;
 
+import static java.util.Collections.unmodifiableMap;
 import static org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 
 import com.chutneytesting.task.spi.injectable.Target;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -13,16 +13,15 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 
 public class KafkaConsumerFactoryFactory {
 
-    public ConsumerFactory<String, String> create(Target target, String group, Map<String, String> properties) {
+    public ConsumerFactory<String, String> create(Target target, String group, Map<String, String> config) {
 
         Map<String, Object> consumerConfig = new HashMap<>();
         consumerConfig.put(BOOTSTRAP_SERVERS_CONFIG, target.url());
         consumerConfig.put(GROUP_ID_CONFIG, group);
-        consumerConfig.putAll(target.properties());
-        consumerConfig.putAll(properties);
+        consumerConfig.putAll(config);
 
         return new DefaultKafkaConsumerFactory<>(
-            Collections.unmodifiableMap(consumerConfig),
+            unmodifiableMap(consumerConfig),
             new StringDeserializer(),
             new StringDeserializer());
     }

--- a/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactory.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactory.java
@@ -1,5 +1,6 @@
 package com.chutneytesting.task.kafka;
 
+import static com.chutneytesting.task.kafka.KafkaClientFactoryHelper.resolveBootStrapServerConfig;
 import static java.util.Collections.unmodifiableMap;
 import static org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
@@ -16,7 +17,7 @@ public class KafkaConsumerFactoryFactory {
     public ConsumerFactory<String, String> create(Target target, String group, Map<String, String> config) {
 
         Map<String, Object> consumerConfig = new HashMap<>();
-        consumerConfig.put(BOOTSTRAP_SERVERS_CONFIG, target.url());
+        consumerConfig.put(BOOTSTRAP_SERVERS_CONFIG, resolveBootStrapServerConfig(target));
         consumerConfig.put(GROUP_ID_CONFIG, group);
         consumerConfig.putAll(config);
 

--- a/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactory.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactory.java
@@ -4,7 +4,8 @@ import static org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 
 import com.chutneytesting.task.spi.injectable.Target;
-import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.kafka.core.ConsumerFactory;
@@ -14,16 +15,15 @@ public class KafkaConsumerFactoryFactory {
 
     public ConsumerFactory<String, String> create(Target target, String group, Map<String, String> properties) {
 
-        Map<String, Object> consumerConfig = ImmutableMap.<String, Object>builder()
-            .put(BOOTSTRAP_SERVERS_CONFIG, target.url())
-            .put(GROUP_ID_CONFIG, group)
-            .putAll(target.properties())
-            .putAll(properties)
-            .build();
+        Map<String, Object> consumerConfig = new HashMap<>();
+        consumerConfig.put(BOOTSTRAP_SERVERS_CONFIG, target.url());
+        consumerConfig.put(GROUP_ID_CONFIG, group);
+        consumerConfig.putAll(target.properties());
+        consumerConfig.putAll(properties);
 
         return new DefaultKafkaConsumerFactory<>(
-                consumerConfig,
-                new StringDeserializer(),
-                new StringDeserializer());
+            Collections.unmodifiableMap(consumerConfig),
+            new StringDeserializer(),
+            new StringDeserializer());
     }
 }

--- a/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTaskTest.java
@@ -45,6 +45,7 @@ import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.MessageListener;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.MimeType;
 import wiremock.com.google.common.collect.ImmutableMap;
 
 @SuppressWarnings("unchecked")
@@ -67,6 +68,46 @@ public class KafkaBasicConsumeTaskTest {
     @BeforeEach
     public void before() {
         logger = new TestLogger();
+    }
+
+    @Test
+    void should_set_inputs_default_values() {
+        KafkaBasicConsumeTask defaultTask = new KafkaBasicConsumeTask(null, null, null, null, null, null, null, null, null, null, null);
+        assertThat(defaultTask)
+            .hasFieldOrPropertyWithValue("topic", null)
+            .hasFieldOrPropertyWithValue("group", null)
+            .hasFieldOrPropertyWithValue("properties", emptyMap())
+            .hasFieldOrPropertyWithValue("nbMessages", 1)
+            .hasFieldOrPropertyWithValue("selector", null)
+            .hasFieldOrPropertyWithValue("headerSelector", null)
+            .hasFieldOrPropertyWithValue("contentType", MimeType.valueOf("application/json"))
+            .hasFieldOrPropertyWithValue("timeout", "60 sec")
+            .hasFieldOrPropertyWithValue("ackMode", "BATCH")
+        ;
+    }
+
+    @Test
+    void should_merge_target_properties_with_input_properties() {
+        Target target = TestTarget.TestTargetBuilder.builder()
+            .withProperty("a.target.property", "a value")
+            .withProperty("property.to.override", "a target value")
+            .build();
+
+        Map<String, String> properties = Map.of(
+            "a.input.property", "a VALUE",
+            "property.to.override", "a property value"
+        );
+
+        Map<String, String> expectedConfig = Map.of(
+            "a.target.property", "a value",
+            "a.input.property", "a VALUE",
+            "property.to.override", "a property value"
+        );
+
+        KafkaBasicConsumeTask defaultTask = new KafkaBasicConsumeTask(target, null, null, properties, null, null, null, null, null, null, null);
+        assertThat(defaultTask)
+            .hasFieldOrPropertyWithValue("properties", expectedConfig)
+        ;
     }
 
     @Test

--- a/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaBasicConsumeTaskTest.java
@@ -359,7 +359,7 @@ public class KafkaBasicConsumeTaskTest {
     }
 
     private KafkaBasicConsumeTask givenKafkaConsumeTask(int expectedMessageNb, String selector, String headerSelector, String mimeType, String timeout) {
-        return new KafkaBasicConsumeTask(TARGET_STUB, TOPIC, GROUP, emptyMap(), expectedMessageNb, selector, headerSelector, mimeType, timeout, logger);
+        return new KafkaBasicConsumeTask(TARGET_STUB, TOPIC, GROUP, emptyMap(), expectedMessageNb, selector, headerSelector, mimeType, timeout, null, logger);
     }
 
     private void givenTaskReceiveMessages(Task task, ConsumerRecord<String, String>... messages) {

--- a/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaBasicPublishTaskTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaBasicPublishTaskTest.java
@@ -2,6 +2,7 @@ package com.chutneytesting.task.kafka;
 
 import static com.chutneytesting.task.spi.TaskExecutionResult.Status.Failure;
 import static com.chutneytesting.task.spi.TaskExecutionResult.Status.Success;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -9,15 +10,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.chutneytesting.task.TestLogger;
+import com.chutneytesting.task.TestTarget;
 import com.chutneytesting.task.spi.Task;
 import com.chutneytesting.task.spi.TaskExecutionResult;
 import com.chutneytesting.task.spi.injectable.Target;
-import com.chutneytesting.task.TestLogger;
-import com.chutneytesting.task.TestTarget;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -36,18 +41,76 @@ public class KafkaBasicPublishTaskTest {
     }
 
     @Test
+    void should_set_inputs_default_values() {
+        KafkaBasicPublishTask defaultTask = new KafkaBasicPublishTask(null, null, null, null, null, null);
+        assertThat(defaultTask)
+            .hasFieldOrPropertyWithValue("topic", null)
+            .hasFieldOrPropertyWithValue("headers", emptyMap())
+            .hasFieldOrPropertyWithValue("payload", null)
+            .hasFieldOrPropertyWithValue("properties", emptyMap())
+        ;
+    }
+
+    @Test
+    void should_validate_all_mandatory_inputs() {
+        KafkaBasicPublishTask defaultTask = new KafkaBasicPublishTask(null, null, null, null, null, null);
+        List<String> errors = defaultTask.validateInputs();
+
+        assertThat(errors.size()).isEqualTo(9);
+        SoftAssertions softly = new SoftAssertions();
+
+        softly.assertThat(errors.get(0)).isEqualTo("No topic provided (String)");
+        softly.assertThat(errors.get(1)).isEqualTo("topic should not be blank");
+
+        softly.assertThat(errors.get(2)).isEqualTo("No payload provided (String)");
+        softly.assertThat(errors.get(3)).isEqualTo("payload should not be blank");
+
+        softly.assertThat(errors.get(4)).isEqualTo("No target provided");
+        softly.assertThat(errors.get(5)).isEqualTo("[Target name is blank] not applied because of exception java.lang.NullPointerException(null)");
+        softly.assertThat(errors.get(6)).isEqualTo("[No url defined on the target] not applied because of exception java.lang.NullPointerException(null)");
+        softly.assertThat(errors.get(7)).isEqualTo("[Target url is not valid] not applied because of exception java.lang.NullPointerException(null)");
+        softly.assertThat(errors.get(8)).isEqualTo("[Target url has an undefined host] not applied because of exception java.lang.NullPointerException(null)");
+
+        softly.assertAll();
+    }
+
+    @Test
+    void should_merge_target_properties_with_input_properties() {
+        Target target = TestTarget.TestTargetBuilder.builder()
+            .withProperty("a.target.property", "a value")
+            .withProperty("property.to.override", "a target value")
+            .build();
+
+        Map<String, String> properties = Map.of(
+            "a.input.property", "a VALUE",
+            "property.to.override", "a property value"
+        );
+
+        Map<String, String> expectedConfig = Map.of(
+            "a.target.property", "a value",
+            "a.input.property", "a VALUE",
+            "property.to.override", "a property value"
+        );
+
+        KafkaBasicPublishTask defaultTask = new KafkaBasicPublishTask(target, null, null, null, properties, null);
+        assertThat(defaultTask)
+            .hasFieldOrPropertyWithValue("properties", expectedConfig)
+        ;
+    }
+
+    @Test
     public void basic_publish_task_should_success() throws Exception {
         //given
         TestLogger logger = new TestLogger();
-        Task task = new KafkaBasicPublishTask(getKafkaTarget(), TOPIC, null, PAYLOAD, logger);
+        Task task = new KafkaBasicPublishTask(getKafkaTarget(), TOPIC, null, PAYLOAD, null, logger);
         //mocks
         ChutneyKafkaProducerFactory producerFactoryMock = mock(ChutneyKafkaProducerFactory.class);
-        KafkaTemplate kafkaTemplateMock = mock(KafkaTemplate.class);
-        when(producerFactoryMock.create(any())).thenReturn(kafkaTemplateMock);
+        KafkaTemplate<String, String> kafkaTemplateMock = mock(KafkaTemplate.class);
+        when(producerFactoryMock.create(any(), any())).thenReturn(kafkaTemplateMock);
 
-        ListenableFuture<SendResult> listenableFutureMock = mock(ListenableFuture.class);
+        ListenableFuture<SendResult<String, String>> listenableFutureMock = mock(ListenableFuture.class);
         when(listenableFutureMock.get(anyLong(), any(TimeUnit.class))).thenReturn(null);
-        when(kafkaTemplateMock.send(any(ProducerRecord.class))).thenReturn(listenableFutureMock);
+        when(kafkaTemplateMock.send(ArgumentMatchers.<ProducerRecord<String, String>>any())).thenReturn(listenableFutureMock);
 
         ReflectionTestUtils.setField(task, "producerFactory", producerFactoryMock);
 
@@ -64,15 +127,15 @@ public class KafkaBasicPublishTaskTest {
     public void basic_publish_task_should_failed_when_timeout() throws Exception {
         //given
         TestLogger logger = new TestLogger();
-        Task task = new KafkaBasicPublishTask(getKafkaTarget(), TOPIC, null, PAYLOAD, logger);
+        Task task = new KafkaBasicPublishTask(getKafkaTarget(), TOPIC, null, PAYLOAD, null, logger);
         //mocks
         ChutneyKafkaProducerFactory producerFactoryMock = mock(ChutneyKafkaProducerFactory.class);
-        KafkaTemplate kafkaTemplateMock = mock(KafkaTemplate.class);
-        when(producerFactoryMock.create(any())).thenReturn(kafkaTemplateMock);
+        KafkaTemplate<String, String> kafkaTemplateMock = mock(KafkaTemplate.class);
+        when(producerFactoryMock.create(any(), any())).thenReturn(kafkaTemplateMock);
 
-        ListenableFuture<SendResult> listenableFutureMock = mock(ListenableFuture.class);
+        ListenableFuture<SendResult<String, String>> listenableFutureMock = mock(ListenableFuture.class);
         when(listenableFutureMock.get(anyLong(), any(TimeUnit.class))).thenThrow(TimeoutException.class);
-        when(kafkaTemplateMock.send(any(ProducerRecord.class))).thenReturn(listenableFutureMock);
+        when(kafkaTemplateMock.send(ArgumentMatchers.<ProducerRecord<String, String>>any())).thenReturn(listenableFutureMock);
 
         ReflectionTestUtils.setField(task, "producerFactory", producerFactoryMock);
 

--- a/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactoryTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactoryTest.java
@@ -1,0 +1,92 @@
+package com.chutneytesting.task.kafka;
+
+import static java.util.Collections.emptyMap;
+import static org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.chutneytesting.task.TestTarget;
+import com.chutneytesting.task.spi.injectable.Target;
+import java.util.Map;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.kafka.core.ConsumerFactory;
+
+class KafkaConsumerFactoryFactoryTest {
+
+    private final TestTarget.TestTargetBuilder targetWithoutProperties = TestTarget.TestTargetBuilder.builder()
+        .withTargetId("kafka")
+        .withUrl("tcp://127.0.0.1:5555");
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.MethodName.class)
+    @DisplayName("should set kafka client bootstrap.servers configuration")
+    class BootstrapServersConfig {
+
+        @Test
+        @DisplayName("from configuration")
+        void a_should_use_configuration_for_bootstrap_servers_kafka_client_configuration() {
+            Target target = targetWithoutProperties
+                .withProperty(BOOTSTRAP_SERVERS_CONFIG, "target.host:6666")
+                .build();
+
+            Map<String, String> config = Map.of(BOOTSTRAP_SERVERS_CONFIG, "conf.host:9999");
+
+            ConsumerFactory<String, String> consumerFactoryFactory = new KafkaConsumerFactoryFactory().create(target, null, config);
+
+            assertThat(consumerFactoryFactory.getConfigurationProperties())
+                .containsEntry(BOOTSTRAP_SERVERS_CONFIG, config.get(BOOTSTRAP_SERVERS_CONFIG));
+        }
+
+        @Test
+        @DisplayName("from target properties")
+        void b_should_use_target_properties_for_bootstrap_servers_kafka_client_configuration() {
+            Target target = targetWithoutProperties
+                .withProperty(BOOTSTRAP_SERVERS_CONFIG, "target.host:6666")
+                .build();
+
+            ConsumerFactory<String, String> consumerFactoryFactory = new KafkaConsumerFactoryFactory().create(target, null, emptyMap());
+
+            assertThat(consumerFactoryFactory.getConfigurationProperties())
+                .containsEntry(BOOTSTRAP_SERVERS_CONFIG, target.properties().get(BOOTSTRAP_SERVERS_CONFIG));
+        }
+
+        @Test
+        @DisplayName("from target's url authority otherwise")
+        void c_should_use_target_authority_url_for_bootstrap_servers_kafka_client_configuration() {
+            Target target = targetWithoutProperties.build();
+
+            ConsumerFactory<String, String> consumerFactoryFactory = new KafkaConsumerFactoryFactory().create(target, null, emptyMap());
+
+            assertThat(consumerFactoryFactory.getConfigurationProperties())
+                .hasEntrySatisfying(BOOTSTRAP_SERVERS_CONFIG, (v) -> assertThat(v).isEqualTo("127.0.0.1:5555"));
+        }
+
+        @Test
+        @DisplayName("fallback to target's url")
+        void d_should_use_target_host_url_for_bootstrap_servers_kafka_client_configuration() {
+            Target target = targetWithoutProperties
+                .withUrl("http:/a/path")
+                .build();
+
+            ConsumerFactory<String, String> consumerFactoryFactory = new KafkaConsumerFactoryFactory().create(target, null, emptyMap());
+
+            assertThat(consumerFactoryFactory.getConfigurationProperties())
+                .hasEntrySatisfying(BOOTSTRAP_SERVERS_CONFIG, (v) -> assertThat(v).isEqualTo(target.url()));
+        }
+    }
+
+    @Test
+    void should_use_StringDeserializer_as_key_and_value_deserializer() {
+        Target target = targetWithoutProperties.build();
+
+        ConsumerFactory<String, String> consumerFactoryFactory = new KafkaConsumerFactoryFactory().create(target, null, emptyMap());
+        assertThat(consumerFactoryFactory.getKeyDeserializer())
+            .isInstanceOf(StringDeserializer.class);
+        assertThat(consumerFactoryFactory.getValueDeserializer())
+            .isInstanceOf(StringDeserializer.class);
+    }
+}

--- a/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactoryTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/kafka/KafkaConsumerFactoryFactoryTest.java
@@ -11,6 +11,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.kafka.core.ConsumerFactory;
@@ -22,13 +23,14 @@ class KafkaConsumerFactoryFactoryTest {
         .withUrl("tcp://127.0.0.1:5555");
 
     @Nested
-    @TestMethodOrder(MethodOrderer.MethodName.class)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @DisplayName("should set kafka client bootstrap.servers configuration")
     class BootstrapServersConfig {
 
         @Test
+        @Order(1)
         @DisplayName("from configuration")
-        void a_should_use_configuration_for_bootstrap_servers_kafka_client_configuration() {
+        void should_use_configuration_for_bootstrap_servers_kafka_client_configuration() {
             Target target = targetWithoutProperties
                 .withProperty(BOOTSTRAP_SERVERS_CONFIG, "target.host:6666")
                 .build();
@@ -42,8 +44,9 @@ class KafkaConsumerFactoryFactoryTest {
         }
 
         @Test
+        @Order(2)
         @DisplayName("from target properties")
-        void b_should_use_target_properties_for_bootstrap_servers_kafka_client_configuration() {
+        void should_use_target_properties_for_bootstrap_servers_kafka_client_configuration() {
             Target target = targetWithoutProperties
                 .withProperty(BOOTSTRAP_SERVERS_CONFIG, "target.host:6666")
                 .build();
@@ -55,8 +58,9 @@ class KafkaConsumerFactoryFactoryTest {
         }
 
         @Test
-        @DisplayName("from target's url authority otherwise")
-        void c_should_use_target_authority_url_for_bootstrap_servers_kafka_client_configuration() {
+        @Order(3)
+        @DisplayName("from target's url authority")
+        void should_use_target_authority_url_for_bootstrap_servers_kafka_client_configuration() {
             Target target = targetWithoutProperties.build();
 
             ConsumerFactory<String, String> consumerFactoryFactory = new KafkaConsumerFactoryFactory().create(target, null, emptyMap());
@@ -66,8 +70,9 @@ class KafkaConsumerFactoryFactoryTest {
         }
 
         @Test
-        @DisplayName("fallback to target's url")
-        void d_should_use_target_host_url_for_bootstrap_servers_kafka_client_configuration() {
+        @Order(4)
+        @DisplayName("from whole target's url otherwise")
+        void should_use_target_host_url_for_bootstrap_servers_kafka_client_configuration() {
             Target target = targetWithoutProperties
                 .withUrl("http:/a/path")
                 .build();

--- a/task-spi/src/main/java/com/chutneytesting/task/spi/validation/TaskValidatorsUtils.java
+++ b/task-spi/src/main/java/com/chutneytesting/task/spi/validation/TaskValidatorsUtils.java
@@ -8,8 +8,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.Callable;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 
 public class TaskValidatorsUtils {
@@ -60,16 +60,16 @@ public class TaskValidatorsUtils {
                     inputLabel + " is not a valid value in " + Arrays.toString((E[]) enumClazz.getMethod("values").invoke(null))
                 );
         } catch (ReflectiveOperationException roe) {
-            throw new IllegalStateException("Oops, enum class does not have the values function !!");
+            throw new IllegalStateException("Should never happens !! unless Enum class does not have the values function !!");
         }
     }
 
-    private static <T, V> Predicate<T> testNoException(Callable<V> r) {
-        return (nan) -> {
+    private static <T, V> Predicate<T> testNoException(Supplier<V> r) {
+        return (x) -> {
             try {
-                r.call();
+                r.get();
                 return true;
-            } catch (Throwable t) {
+            } catch (Exception e) {
                 return false;
             }
         };

--- a/task-spi/src/test/java/com/chutneytesting/task/spi/validation/ValidatorTest.java
+++ b/task-spi/src/test/java/com/chutneytesting/task/spi/validation/ValidatorTest.java
@@ -1,9 +1,14 @@
 package com.chutneytesting.task.spi.validation;
 
-
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Index.atIndex;
 
+import java.util.List;
 import java.util.Objects;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -66,5 +71,38 @@ class ValidatorTest {
         public Integer getAge() {
             return age;
         }
+    }
+
+    @ParameterizedTest()
+    @MethodSource("parametersForShould_validate_string_as_enum")
+    void should_validate_string_as_enum(String input, boolean expected, int numberOfErrors) {
+        Validator<String> validateAString = TaskValidatorsUtils.enumValidation(InnerEnum.class, input, "label");
+        assertThat(validateAString.isValid()).isEqualTo(expected);
+        assertThat(validateAString.getErrors().size()).isEqualTo(numberOfErrors);
+    }
+
+    private enum InnerEnum {ONE, TWO, THREE}
+
+    public static Object[] parametersForShould_validate_string_as_enum() {
+        return new Object[][]{
+            {"ONE", true, 0},
+            {"FOUR", false, 1}
+        };
+    }
+
+    @Test
+    void TODO_should_not_say_failing_validation_is_not_applied_when_validation_consists_of_exception_checking() {
+        Validator<List<Object>> validation = Validator.of(emptyList())
+            .validate(l -> l.get(1), noException -> true, "validation message");
+
+        Condition<String> doesNotHaveNotAppliedMessage = new Condition<>(
+            s -> !s.contains("not applied"),
+            "Should not contains 'not applied'"
+        );
+
+        // TODO - Does not like the current behavior
+        Assertions.assertThrows(AssertionError.class,
+            () -> assertThat(validation.getErrors()).has(doesNotHaveNotAppliedMessage, atIndex(0))
+        );
     }
 }


### PR DESCRIPTION
#### Describe the changes you've made

Add in Kafka consume task a new input **ackMode** : the Spring kafka client acknowledge mode.
By default, **BATCH** modeis used, as Spring.
For TIME, COUNT and COUNT_TIME modes, one could use the configuration keys **auto.commit.interval.ms** (as in Kafka client) and **auto.commit.count**.
If the **MANUAL** mode is used, the task will not commit any offset, therefore reading the same messages on sequential use.

Those new configuration keys could be set on target as well.

Spring kafka, by default, set **enable.auto.commit** to false and use for its kafka client container the **BATCH** acknowledge mode.

cf.
https://docs.spring.io/spring-kafka/reference/html/#receiving-messages
https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html

Add new static validation method for enum.

#### Test plan

Modify existing ok test to test **BATCH** mode.
Add integration test with all modes in sequential consumes after a publish.

Add unit test for validation and a TODO to emphasize a annoyance.

#### Checklist

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
