### PR TITLE
fix mongodb and kafka versions after springboot upgrade

### DIFF
--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
@@ -71,16 +71,12 @@ public class DefaultExecutionEngine implements ExecutionEngine {
 
                     final StepExecutionStrategy strategy = stepExecutionStrategies.buildStrategyFrom(rootStep.get());
                     strategy.execute(execution, rootStep.get(), scenarioContext, stepExecutionStrategies);
-                } catch (RuntimeException e ) {
+                }
+                catch (RuntimeException | NoClassDefFoundError e ) {
                     // Do not remove this fault barrier, the engine must not be stopped by external events
                     // (such as exceptions not raised by the engine)
                     rootStep.get().failure(e);
                     LOGGER.warn("Intercepted exception in root step execution !", e);
-                } catch (NoClassDefFoundError e) {
-                    // Do not remove this fault barrier, the engine must not be stopped by external events
-                    // (such as exceptions not raised by the engine)
-                    rootStep.get().failure(e);
-                    LOGGER.warn("Intercepted NoClassDefFoundError in root step execution !", e);
                 }
 
                 executeFinallyActions(execution, rootStep, scenarioContext);

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
@@ -71,11 +71,16 @@ public class DefaultExecutionEngine implements ExecutionEngine {
 
                     final StepExecutionStrategy strategy = stepExecutionStrategies.buildStrategyFrom(rootStep.get());
                     strategy.execute(execution, rootStep.get(), scenarioContext, stepExecutionStrategies);
-                } catch (RuntimeException e) {
+                } catch (RuntimeException e ) {
                     // Do not remove this fault barrier, the engine must not be stopped by external events
                     // (such as exceptions not raised by the engine)
                     rootStep.get().failure(e);
                     LOGGER.warn("Intercepted exception in root step execution !", e);
+                } catch (NoClassDefFoundError e) {
+                    // Do not remove this fault barrier, the engine must not be stopped by external events
+                    // (such as exceptions not raised by the engine)
+                    rootStep.get().failure(e);
+                    LOGGER.warn("Intercepted NoClassDefFoundError in root step execution !", e);
                 }
 
                 executeFinallyActions(execution, rootStep, scenarioContext);

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
@@ -158,11 +158,11 @@ public class Step {
         state.addErrors(errors);
     }
 
-    public void failure(Exception e) {
+    public void failure(Exception e ) {
         failure(ofNullable(e.getMessage()).orElse(e.toString()));
     }
 
-    public void failure(Error e) {
+    public void failure(Throwable e) {
         failure(ofNullable(e.getMessage()).orElse(e.toString()));
     }
 

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
@@ -162,6 +162,10 @@ public class Step {
         failure(ofNullable(e.getMessage()).orElse(e.toString()));
     }
 
+    public void failure(Error e) {
+        failure(ofNullable(e.getMessage()).orElse(e.toString()));
+    }
+
     public void failure(String... message) {
         state.errorOccurred(message);
     }

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
@@ -158,10 +158,6 @@ public class Step {
         state.addErrors(errors);
     }
 
-    public void failure(Exception e ) {
-        failure(ofNullable(e.getMessage()).orElse(e.toString()));
-    }
-
     public void failure(Throwable e) {
         failure(ofNullable(e.getMessage()).orElse(e.toString()));
     }
@@ -242,11 +238,11 @@ public class Step {
     private void copyStepResultsToScenarioContext(StepContextImpl stepContext, ScenarioContext scenarioContext) {
         Map<String, Object> contextAndStepResults = stepContext.allEvaluatedVariables();
         Try.exec(() -> {
-            Map<String, Object> evaluatedOutputs = dataEvaluator.evaluateNamedDataWithContextVariables(definition.outputs, contextAndStepResults);
-            stepContext.stepOutputs.putAll(evaluatedOutputs);
-            scenarioContext.putAll(evaluatedOutputs);
-            return null;
-        })
+                Map<String, Object> evaluatedOutputs = dataEvaluator.evaluateNamedDataWithContextVariables(definition.outputs, contextAndStepResults);
+                stepContext.stepOutputs.putAll(evaluatedOutputs);
+                scenarioContext.putAll(evaluatedOutputs);
+                return null;
+            })
             .ifFailed(e -> failure("Cannot evaluate outputs."
                 + " - Exception: " + e.getClass() + " with message: \"" + e.getMessage() + "\""));
     }
@@ -254,18 +250,18 @@ public class Step {
     private void executeStepValidations(StepContextImpl stepContext) {
         Map<String, Object> contextAndStepResults = stepContext.allEvaluatedVariables();
         Try.exec(() -> {
-            Map<String, Object> evaluatedValidations = dataEvaluator.evaluateNamedDataWithContextVariables(definition.validations, contextAndStepResults);
-            evaluatedValidations.forEach((k, v) -> {
-                if (!(boolean) v) {
-                    failure("Validation [" + k + "] : KO (" + definition.validations.get(k).toString() + ")");
-                } else {
-                    state.addInformation("Validation [" + k + "] : OK");
-                }
-            });
-            return null;
-        })
-        .ifFailed(e -> failure("Step validation failed."
-            + " - Exception: " + e.getClass() + " with message: \"" + e.getMessage() + "\""));
+                Map<String, Object> evaluatedValidations = dataEvaluator.evaluateNamedDataWithContextVariables(definition.validations, contextAndStepResults);
+                evaluatedValidations.forEach((k, v) -> {
+                    if (!(boolean) v) {
+                        failure("Validation [" + k + "] : KO (" + definition.validations.get(k).toString() + ")");
+                    } else {
+                        state.addInformation("Validation [" + k + "] : OK");
+                    }
+                });
+                return null;
+            })
+            .ifFailed(e -> failure("Step validation failed."
+                + " - Exception: " + e.getClass() + " with message: \"" + e.getMessage() + "\""));
     }
 
     public void addStepExecution(Step step) {

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
@@ -68,10 +68,10 @@ public class DefaultExecutionEngineTest {
         Long executionId = engine.execute(stepDefinition, ScenarioExecution.createScenarioExecution(null));
         StepExecutionReport report = reporter.subscribeOnExecution(executionId).blockingLast();
 
-        Assertions.assertThat(executionId).isNotNull();
-        Assertions.assertThat(report).isNotNull();
-        Assertions.assertThat(report.errors).hasSize(1);
-        Assertions.assertThat(report.errors.get(0)).isEqualTo(throwableMessage);
+        assertThat(executionId).isNotNull();
+        assertThat(report).isNotNull();
+        assertThat(report.errors).hasSize(1);
+        assertThat(report.errors.get(0)).isEqualTo(throwableMessage);
     }
 
     @ParameterizedTest

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
@@ -31,10 +31,15 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class DefaultExecutionEngineTest {
 
@@ -43,13 +48,15 @@ public class DefaultExecutionEngineTest {
     private final DelegationService delegationService = mock(DelegationService.class);
     private final String fakeEnvironment = "";
     private final Executor taskExecutor = Executors.newFixedThreadPool(1);
+    private static final String throwableMessage = "Should be catch by fault barrier";
 
-    @Test
-    public void runtime_exception_should_be_catch_by_fault_barrier() {
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("throwable_caught_by_fault_barrier")
+    public void no_class_def_found_error_and_runtime_exception_should_be_catch_by_fault_barrier(Supplier<Throwable> throwable) {
         //Given
         StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
         when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy);
-        when(strategy.execute(any(), any(), any(), any())).thenThrow(new RuntimeException("Should be catch by fault barrier"));
+        when(strategy.execute(any(), any(), any(), any())).thenThrow(throwable.get());
 
         Reporter reporter = new Reporter();
         DefaultExecutionEngine engine = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, taskExecutor);
@@ -64,7 +71,7 @@ public class DefaultExecutionEngineTest {
         Assertions.assertThat(executionId).isNotNull();
         Assertions.assertThat(report).isNotNull();
         Assertions.assertThat(report.errors).hasSize(1);
-        Assertions.assertThat(report.errors.get(0)).isEqualTo("Should be catch by fault barrier");
+        Assertions.assertThat(report.errors.get(0)).isEqualTo(throwableMessage);
     }
 
     @ParameterizedTest
@@ -104,12 +111,13 @@ public class DefaultExecutionEngineTest {
         assertThat(finalStep.subSteps().get(0).definition().name).isEqualTo(finallyAction.name());
     }
 
-    @Test
-    public void should_execute_finally_actions_on_runtime_exception() {
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("throwable_caught_by_fault_barrier")
+    public void should_execute_finally_actions_on_runtime_exception_or_no_class_def_found_error(Supplier<Throwable> throwable) {
         //Given
         StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
         when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy).thenReturn(DefaultStepExecutionStrategy.instance);
-        when(strategy.execute(any(), any(), any(), any())).thenThrow(new RuntimeException("Should be catch by fault barrier"));
+        when(strategy.execute(any(), any(), any(), any())).thenThrow(throwable.get());
 
         Reporter reporter = new Reporter();
         DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, taskExecutor);
@@ -221,5 +229,12 @@ public class DefaultExecutionEngineTest {
         assertThat(rootStep.subSteps().get(0).definition().name).isEqualTo("TearDown");
         assertThat(rootStep.subSteps().get(0).definition().steps.size()).isEqualTo(1);
         assertThat(rootStep.subSteps().get(0).definition().steps.get(0).name).isEqualTo(finallyAction.name());
+    }
+
+    private static Stream<Arguments> throwable_caught_by_fault_barrier () {
+       return Stream.of(
+            Arguments.of(Named.of("RuntimeException", (Supplier<Throwable>) () -> new RuntimeException(throwableMessage))),
+            Arguments.of(Named.of("NoClassDefFoundError", (Supplier<Throwable>) () -> new NoClassDefFoundError(throwableMessage)))
+       );
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,8 @@
 
         <springboot.version>2.6.3</springboot.version>
         <spring.version>5.6.1</spring.version> <!-- Be careful to follow springboot version-->
-        <spring-kafka-test.version>2.8.1</spring-kafka-test.version> <!-- must downgrade because there is a bug in 3.0.0 https://docs.spring.io/spring-kafka/docs/2.8.1-SNAPSHOT/reference/html/#update-deps -->
+        <spring-kafka.version>2.8.2</spring-kafka.version> <!-- Be careful to follow springboot version-->
+        <kafka.version>2.8.1</kafka.version> <!-- https://docs.spring.io/spring-kafka/docs/2.8.2/reference/html/#update-deps -->
         <jackson.version>2.13.1</jackson.version>
         <guava.version>31.0.1-jre</guava.version>
         <immutables.version>2.8.8</immutables.version>
@@ -313,10 +314,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- -->
             <dependency>
                 <groupId>org.springframework.kafka</groupId>
                 <artifactId>spring-kafka-test</artifactId>
-                <version>${spring-kafka-test.version}</version>
+                <version>${spring-kafka.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>junit</groupId>
@@ -329,6 +331,23 @@
                     <exclusion>
                         <groupId>org.apache.zookeeper</groupId>
                         <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_2.13</artifactId>
+                <version>${kafka.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <artifactId>jackson-module-scala_2.13</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
 
         <springboot.version>2.6.3</springboot.version>
         <spring.version>5.6.1</spring.version> <!-- Be careful to follow springboot version-->
+        <spring-kafka-test.version>2.8.1</spring-kafka-test.version> <!-- must downgrade because there is a bug in 3.0.0 https://docs.spring.io/spring-kafka/docs/2.8.1-SNAPSHOT/reference/html/#update-deps -->
         <jackson.version>2.13.1</jackson.version>
         <guava.version>31.0.1-jre</guava.version>
         <immutables.version>2.8.8</immutables.version>
@@ -312,6 +313,25 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.kafka</groupId>
+                <artifactId>spring-kafka-test</artifactId>
+                <version>${spring-kafka-test.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <artifactId>jackson-module-scala_2.13</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <!-- External dependencies -->
             <dependency>
@@ -443,12 +463,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver</artifactId>
-                <version>${mongodb-driver.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver-core</artifactId>
+                <artifactId>mongodb-driver-sync</artifactId>
                 <version>${mongodb.version}</version>
             </dependency>
             <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -274,16 +274,6 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.module</groupId>
-                    <artifactId>jackson-module-scala_2.13</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- Note that the below is qpid-broker-core and *not* qpid-broker. -->
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -271,6 +271,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.13</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>

--- a/task-impl/pom.xml
+++ b/task-impl/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver</artifactId>
+            <artifactId>mongodb-driver-sync</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
@@ -146,16 +146,6 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.module</groupId>
-                    <artifactId>jackson-module-scala_2.13</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- Selemnium tasks-->
         <dependency>

--- a/task-impl/pom.xml
+++ b/task-impl/pom.xml
@@ -143,6 +143,15 @@
             <artifactId>spring-kafka</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.13</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka-test</artifactId>
             <scope>compile</scope>

--- a/task-impl/src/main/java/com/chutneytesting/task/mongo/DefaultMongoDatabaseFactory.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/mongo/DefaultMongoDatabaseFactory.java
@@ -5,11 +5,10 @@ import com.chutneytesting.tools.CloseableResource;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCredential;
-import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class DefaultMongoDatabaseFactory implements MongoDatabaseFactory {
 
@@ -19,12 +18,11 @@ public class DefaultMongoDatabaseFactory implements MongoDatabaseFactory {
             throw new IllegalArgumentException("Missing Target property 'databaseName'");
         }
 
-        ServerAddress serverAddress = new ServerAddress(target.host(), target.port());
-        String conns = String.format("mongodb://%s:%d/?replicaSet=rs0", target.host(), target.port());
+        String connectionString = String.format("mongodb://%s:%d/", target.host(), target.port());
 
         final MongoClient mongoClient;
         MongoClientSettings.Builder mongoClientSettings = MongoClientSettings.builder()
-            .applyConnectionString(new ConnectionString(conns));
+            .applyConnectionString(new ConnectionString(connectionString));
 
         if (target.security().credential().isPresent()) {
             MongoCredential credential = MongoCredential.createCredential(target.security().credential().get().username(), databaseName, target.security().credential().get().password().toCharArray());


### PR DESCRIPTION
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made
- catch NoClassDefFoundError in DefaultExecutionEngine
- use mongodb-driver-sync 4.4.1 instead of old mongodb-driver.
- use  apache.kafka 2.8.1 version (as mentioned in https://docs.spring.io/spring-kafka/docs/2.8.2/reference/html/#update-deps) instead of 3.0.0 to fix embedded kafka broker issue on windows (https://issues.apache.org/jira/browse/KAFKA-13391)

<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->
NA
<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->
run tests on Windows
<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
