### PR TITLE
Get local IP reachable from remote IP #860

### DIFF
--- a/task-impl/src/main/java/com/chutneytesting/task/function/NetworkFunctions.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/function/NetworkFunctions.java
@@ -10,6 +10,7 @@ import com.chutneytesting.task.spi.SpelFunction;
 import com.chutneytesting.tools.SocketUtils;
 import com.chutneytesting.tools.ThrowingFunction;
 import com.chutneytesting.tools.ThrowingPredicate;
+import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Random;
@@ -130,6 +131,17 @@ public class NetworkFunctions {
             .filter(ip -> matches(regex, ip))
             .findFirst()
             .orElse(InetAddress.getLocalHost().getHostAddress());
+    }
+
+    @SpelFunction
+    public static String hostIpReaching(String remoteHost) throws Exception {
+        // Note : remotePort is not important : No real connection is required here, we only need
+        // to resolve routing table
+        final int remotePort = 8888;
+        try (final DatagramSocket socket = new DatagramSocket()){
+            socket.connect(InetAddress.getByName(remoteHost), remotePort);
+            return socket.getLocalAddress().getHostAddress();
+        }
     }
 
     private static Boolean matches(String regex, String text) {

--- a/task-impl/src/main/java/com/chutneytesting/task/function/NetworkFunctions.java
+++ b/task-impl/src/main/java/com/chutneytesting/task/function/NetworkFunctions.java
@@ -138,7 +138,7 @@ public class NetworkFunctions {
         // Note : remotePort is not important : No real connection is required here, we only need
         // to resolve routing table
         final int remotePort = 8888;
-        try (final DatagramSocket socket = new DatagramSocket()){
+        try (final DatagramSocket socket = new DatagramSocket()) {
             socket.connect(InetAddress.getByName(remoteHost), remotePort);
             return socket.getLocalAddress().getHostAddress();
         }

--- a/task-impl/src/test/java/com/chutneytesting/task/function/NetworkFunctionsTest.java
+++ b/task-impl/src/test/java/com/chutneytesting/task/function/NetworkFunctionsTest.java
@@ -15,4 +15,10 @@ class NetworkFunctionsTest {
     void hostIpMatching() throws Exception {
         assertThat(NetworkFunctions.hostIpMatching("127.0.*")).matches("127.0.0.1");
     }
+
+    @Test
+    void hostIpReaching() throws Exception {
+        final String ip = NetworkFunctions.hostIpReaching("127.0.0.2");
+        assertThat(ip).isEqualTo("127.0.0.1");
+    }
 }


### PR DESCRIPTION
#### Issue Number
fixes #860

#### Describe the changes you've made

* Added function `hostIpReaching` that takes a remote host (as string) (which can be either an ip address or a host name), and returns the local ip that can reach that host
* I didn't use `isReachable` as it doesn't seems to allow to specify the local ip used to reach the remote host. So I created a connection to the remote host "as basic as possible" to read the local ip used to create that connection, and it seems to work
* I've tested the code on both windows and linux, and it seems to work:
  * on different hosts connected to different network (with different local ip used)
  * even on remote hosts that doesn't exists (so only the local routing information is used, no need for the connection to really exists, for the ip to be returned)
* I've also provided unit test, but it only probe the local network in order to be valid on any host

#### Describe if there is any unusual behaviour of your code

* Creation of a `DatagramSocket` requires a port. The code used the arbitrary port 8888. It doesn't matters as the connection doesn't really need to be established in order for the code to work as excepted.

#### Additional context 

N/A

#### Test plan

N/A

#### Checklist

- [x] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
