### PR TITLE
chore(ui+env): hide target password value

### DIFF
--- a/environment/src/main/java/com/chutneytesting/environment/api/dto/TargetDto.java
+++ b/environment/src/main/java/com/chutneytesting/environment/api/dto/TargetDto.java
@@ -1,5 +1,6 @@
 package com.chutneytesting.environment.api.dto;
 
+import static com.chutneytesting.environment.domain.PropertiesTools.hidePassword;
 import static com.chutneytesting.tools.Entry.toEntrySet;
 import static java.util.Collections.emptySet;
 
@@ -35,7 +36,7 @@ public class TargetDto {
         return new TargetDto(
             target.name,
             target.url,
-            toEntrySet(target.properties)
+            hidePassword(toEntrySet(target.properties))
         );
     }
 

--- a/environment/src/main/java/com/chutneytesting/environment/domain/Environment.java
+++ b/environment/src/main/java/com/chutneytesting/environment/domain/Environment.java
@@ -80,7 +80,10 @@ public class Environment {
                     }
                     Set<Target> updatedTargets = new HashSet<>(targets);
                     updatedTargets.remove(t);
-                    updatedTargets.add(targetToUpdate);
+                    updatedTargets.add(Target.builder()
+                        .copyOf(targetToUpdate)
+                        .withPasswordProperties(t.properties)
+                        .build());
 
                     return Environment.builder()
                         .from(this)

--- a/environment/src/main/java/com/chutneytesting/environment/domain/PropertiesTools.java
+++ b/environment/src/main/java/com/chutneytesting/environment/domain/PropertiesTools.java
@@ -1,0 +1,34 @@
+package com.chutneytesting.environment.domain;
+
+import com.chutneytesting.tools.Entry;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PropertiesTools {
+    public final static String HIDDEN_PASSWORD = "**********";
+
+    public static Set<Entry> hidePassword(Set<Entry> set) {
+        return set.stream()
+            .map(e -> new Entry(e.key, (isPasswordKeyword(e.key)) ? HIDDEN_PASSWORD : e.value))
+            .collect(Collectors.toSet());
+    }
+
+    static boolean propertiesEquals(Map<String, String> a, Map<String, String> b) {
+        return a.keySet().equals(b.keySet())
+            && b.entrySet().stream()
+            .filter(e -> !isPasswordEntry(e) || !e.getValue().equals(HIDDEN_PASSWORD))
+            .allMatch(e -> a.containsKey(e.getKey())
+                && a.get(e.getKey()).equals(e.getValue()));
+    }
+
+    static boolean isPasswordKeyword(String keyword) {
+        Set<String> passwordKeywordList = Set.of("password", "pwd");
+        return passwordKeywordList.stream().anyMatch(s -> keyword.toLowerCase(Locale.ROOT).contains(s));
+    }
+
+    static boolean isPasswordEntry(Map.Entry<String, String> entry) {
+        return isPasswordKeyword(entry.getKey());
+    }
+}

--- a/environment/src/main/java/com/chutneytesting/environment/domain/Target.java
+++ b/environment/src/main/java/com/chutneytesting/environment/domain/Target.java
@@ -1,5 +1,7 @@
 package com.chutneytesting.environment.domain;
 
+import static com.chutneytesting.environment.domain.PropertiesTools.HIDDEN_PASSWORD;
+import static com.chutneytesting.environment.domain.PropertiesTools.propertiesEquals;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Optional.ofNullable;
@@ -7,6 +9,7 @@ import static java.util.Optional.ofNullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class Target {
 
@@ -64,6 +67,15 @@ public class Target {
             return this;
         }
 
+        public TargetBuilder withPasswordProperties(Map<String, String> value) {
+            this.properties.putAll(this.properties.entrySet()
+                .stream()
+                .filter(PropertiesTools::isPasswordEntry)
+                .filter(e -> value.containsKey(e.getKey()) && e.getValue().equals(HIDDEN_PASSWORD))
+                .collect(Collectors.toMap(p -> p.getKey(), p -> value.get(p.getKey()))));
+            return this;
+        }
+
         public TargetBuilder withProperty(String key, String value) {
             this.properties.put(key, value);
             return this;
@@ -91,7 +103,7 @@ public class Target {
         Target target = (Target) o;
         return Objects.equals(environment, target.environment) &&
             Objects.equals(url, target.url) &&
-            Objects.equals(properties, target.properties) &&
+            propertiesEquals(properties, target.properties) &&
             Objects.equals(name, target.name);
     }
 

--- a/ui/src/app/atoms/forms/input/input.component.ts
+++ b/ui/src/app/atoms/forms/input/input.component.ts
@@ -6,7 +6,7 @@ template: `
     <input
         id="{{id}}"
         name="{{id}}"
-        type="{{type}}"
+        type="{{isPassword(id)? 'password' : 'text'}}"
         placeholder="{{placeholder}}"
         [ngModel]="model"
         (ngModelChange)="onInputChange($event)"
@@ -24,6 +24,7 @@ export class InputComponent {
     @Input() model: string;
     @Output() modelChange = new EventEmitter<string>();
     @Input() validate: (value: string) => boolean = (_) => true;
+    @Input() hidePassword: boolean = false;
 
     constructor() { }
 
@@ -31,4 +32,14 @@ export class InputComponent {
         this.model = newValue;
         this.modelChange.emit(this.model);
     }
+
+    isPassword(key: string): boolean{
+        var keywordList = ['password','pwd'];
+        var isPassword;
+        keywordList.forEach( (keyword) => {
+            isPassword ||= key.toLowerCase().includes(keyword);
+        });
+        return this.hidePassword && isPassword;
+    }
+
 }

--- a/ui/src/app/molecules/panel/property-table-panel/property-table-panel.component.html
+++ b/ui/src/app/molecules/panel/property-table-panel/property-table-panel.component.html
@@ -10,10 +10,10 @@
     <tbody>
         <tr *ngFor="let entry of entries">
             <td>
-                <chutney-forms-input id="{{entry.key}} + '_key_input'" placeholder="Key" [(model)]="entry.key" [validate]="validationService.isNotEmpty"></chutney-forms-input>
+                <chutney-forms-input id="{{entry.key + '_key_input'}}" placeholder="Key" [(model)]="entry.key" [validate]="validationService.isNotEmpty"></chutney-forms-input>
             </td>
             <td>
-                <chutney-forms-input id="{{entry.key}} + '_value_input'" placeholder="Value" [(model)]="entry.value" [validate]="validationService.isNotEmpty"></chutney-forms-input>
+                <chutney-forms-input id="{{entry.key + '_value_input'}}" placeholder="Value" [(model)]="entry.value" [validate]="validationService.isNotEmpty" [hidePassword]="true" ></chutney-forms-input>
             </td>
             <td><button type="button" class="btn btn-lg ms-3" (click)="deleteEntry(entry)"><span class="fa fa-trash" style="color: red;"></span></button></td>
         </tr>


### PR DESCRIPTION
#### Issue Number
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made
ui : when target property key match [password,pwd] value input switch to password type
env: target password property value are replace by asterisk before send it to front

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->
![image](https://user-images.githubusercontent.com/4257719/194004000-f1193232-7653-4464-b936-a6c1f0471f3f.png)


#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [X] New java code is covered by tests
- [ ] All new and existing tests pass
- [X] No git conflict
