### PR TITLE
fix(engine): scenario execution fault barrier extension to catch Throwable but VM Errors

### DIFF
--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
@@ -1,242 +1,213 @@
 package com.chutneytesting.engine.domain.execution.engine;
 
-import static com.chutneytesting.engine.domain.execution.RxBus.getInstance;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.chutneytesting.action.spi.FinallyAction;
 import com.chutneytesting.engine.domain.delegation.DelegationService;
 import com.chutneytesting.engine.domain.execution.ScenarioExecution;
 import com.chutneytesting.engine.domain.execution.StepDefinition;
 import com.chutneytesting.engine.domain.execution.engine.evaluation.StepDataEvaluator;
-import com.chutneytesting.engine.domain.execution.engine.step.Step;
-import com.chutneytesting.engine.domain.execution.event.BeginStepExecutionEvent;
-import com.chutneytesting.engine.domain.execution.event.EndScenarioExecutionEvent;
 import com.chutneytesting.engine.domain.execution.report.Status;
 import com.chutneytesting.engine.domain.execution.report.StepExecutionReport;
-import com.chutneytesting.engine.domain.execution.strategies.DefaultStepExecutionStrategy;
 import com.chutneytesting.engine.domain.execution.strategies.SoftAssertStrategy;
 import com.chutneytesting.engine.domain.execution.strategies.StepExecutionStrategies;
 import com.chutneytesting.engine.domain.execution.strategies.StepExecutionStrategy;
-import com.chutneytesting.engine.domain.execution.strategies.StepStrategyDefinition;
-import com.chutneytesting.engine.domain.execution.strategies.StrategyProperties;
 import com.chutneytesting.engine.domain.report.Reporter;
-import com.chutneytesting.action.spi.FinallyAction;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class DefaultExecutionEngineTest {
+class DefaultExecutionEngineTest {
 
     private final StepDataEvaluator dataEvaluator = mock(StepDataEvaluator.class);
     private final StepExecutionStrategies stepExecutionStrategies = mock(StepExecutionStrategies.class);
     private final DelegationService delegationService = mock(DelegationService.class);
     private final String fakeEnvironment = "env";
-    private final Executor actionExecutor = Executors.newFixedThreadPool(1);
-    private static final String throwableMessage = "Should be catch by fault barrier";
+    private final Executor actionExecutor = Executors.newSingleThreadExecutor();
+    public static final String tearDownRootNodeName = "TearDown";
+    private static final String throwableToCatchMessage = "Should be caught by fault barrier";
+    private static final String throwableToNotCatchMessage = "Should not be caught by fault barrier";
 
     @ParameterizedTest(name = "{index}: {0}")
-    @MethodSource("throwable_caught_by_fault_barrier")
-    public void linkage_error_and_runtime_exception_should_be_catch_by_fault_barrier(Supplier<Throwable> throwable) {
-        //Given
+    @MethodSource("execution_throwable")
+    void protect_step_definition_execution_by_fault_barrier_unless_vm_error(Supplier<Throwable> throwable) {
+        // Given
         StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
-        when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy);
         when(strategy.execute(any(), any(), any(), any())).thenThrow(throwable.get());
+        when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy);
 
         Reporter reporter = new Reporter();
-        DefaultExecutionEngine engine = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, actionExecutor);
-        StrategyProperties strategyProperties = new StrategyProperties();
-        StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("retry", strategyProperties);
-        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null, null, fakeEnvironment);
-
-        //When
-        Long executionId = engine.execute(stepDefinition, ScenarioExecution.createScenarioExecution(null));
-        StepExecutionReport report = reporter.subscribeOnExecution(executionId).blockingLast();
-
-        assertThat(executionId).isNotNull();
-        assertThat(report).isNotNull();
-        assertThat(report.errors).hasSize(1);
-        assertThat(report.errors.get(0)).isEqualTo(throwableMessage);
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = Status.class, names = {"SUCCESS", "FAILURE", "STOPPED"})
-    public void should_execute_finally_actions_on_scenario_end(Status endStatus) {
-        //Given
-        Reporter reporter = new Reporter();
-        DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, actionExecutor);
-
-        StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
-        when(stepExecutionStrategies.buildStrategyFrom(any()))
-            .thenReturn(strategy) // for step definition
-            .thenReturn(new SoftAssertStrategy()); // for final action step
-        when(strategy.execute(any(), any(), any(), any())).thenReturn(endStatus);
-
+        DefaultExecutionEngine sut = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, actionExecutor);
         StepDefinition stepDefinition = new StepDefinition("name", null, "type", null, null, null, null, null, fakeEnvironment);
 
-        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
-        FinallyAction finallyAction = FinallyAction.Builder.forAction("final", "action name").build();
-        scenarioExecution.registerFinallyAction(finallyAction);
-
-        List<BeginStepExecutionEvent> events = new ArrayList<>();
-        getInstance().registerOnExecutionId(BeginStepExecutionEvent.class, scenarioExecution.executionId, e -> events.add((BeginStepExecutionEvent) e));
-
         // When
-        engineUnderTest.execute(stepDefinition, scenarioExecution);
-        reporter.subscribeOnExecution(scenarioExecution.executionId).blockingLast();
-        await().until(() -> events.size() == 2);
+        Long executionId = sut.execute(stepDefinition, ScenarioExecution.createScenarioExecution(null));
+        assertThat(executionId).isNotNull();
+        StepExecutionReport report = reporter.subscribeOnExecution(executionId).blockingLast();
+        assertThat(report).isNotNull();
 
         // Then
-        assertThat(scenarioExecution.hasToStop()).isFalse();
-
-        Step finalStep = events.get(0).step;
-        assertThat(finalStep.type()).isEqualTo("");
-        assertThat(finalStep.definition().name).isEqualTo("TearDown");
-        assertThat(finalStep.subSteps().get(0).definition().type).isEqualTo(finallyAction.type());
-        assertThat(finalStep.subSteps().get(0).definition().name).isEqualTo(finallyAction.name());
-    }
-
-    @ParameterizedTest(name = "{index}: {0}")
-    @MethodSource("throwable_caught_by_fault_barrier")
-    public void should_execute_finally_actions_on_runtime_exception_or_linkage_error(Supplier<Throwable> throwable) {
-        //Given
-        StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
-        when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy).thenReturn(DefaultStepExecutionStrategy.instance);
-        when(strategy.execute(any(), any(), any(), any())).thenThrow(throwable.get());
-
-        Reporter reporter = new Reporter();
-        DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, actionExecutor);
-        StrategyProperties strategyProperties = new StrategyProperties();
-        StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("retry", strategyProperties);
-        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null, null, fakeEnvironment);
-
-        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
-        FinallyAction finallyAction = FinallyAction.Builder.forAction("final", "action name").build();
-        scenarioExecution.registerFinallyAction(finallyAction);
-
-        List<BeginStepExecutionEvent> events = new ArrayList<>();
-        getInstance().registerOnExecutionId(BeginStepExecutionEvent.class, scenarioExecution.executionId, e -> events.add((BeginStepExecutionEvent) e));
-
-        // When
-        Long executionId = engineUnderTest.execute(stepDefinition, scenarioExecution);
-        reporter.subscribeOnExecution(executionId).blockingLast();
-
-        // Then
-        assertThat(scenarioExecution.hasToStop()).isFalse();
-
-        Step finalRootStep = events.get(0).step;
-        assertThat(finalRootStep.type()).isEqualTo("");
-        assertThat(finalRootStep.definition().name).isEqualTo("TearDown");
-        assertThat(finalRootStep.definition().steps.get(0).type).isEqualTo(finallyAction.type());
-        assertThat(finalRootStep.definition().steps.get(0).name).isEqualTo(finallyAction.name());
+        if (throwable.get() instanceof VirtualMachineError) {
+            assertThat(report.status).isEqualTo(Status.NOT_EXECUTED);
+            assertThat(report.errors).hasSize(0);
+        } else {
+            assertThat(report.status).isEqualTo(Status.FAILURE);
+            assertThat(report.errors).hasSize(1);
+            assertThat(report.errors.get(0)).isEqualTo(throwableToCatchMessage);
+        }
     }
 
     @Test
-    public void finally_actions_are_executed_in_declaration_order() {
+    void execute_tear_down_after_step_definition_attaching_it_to_root_step() {
         // Given
-        Reporter reporter = new Reporter();
-        DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, actionExecutor);
-
         StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
+        when(strategy.execute(any(), any(), any(), any()))
+            .thenReturn(Status.SUCCESS) // for step definition
+            .thenReturn(Status.SUCCESS); // for tear down step
         when(stepExecutionStrategies.buildStrategyFrom(any()))
             .thenReturn(strategy) // for step definition
-            .thenReturn(new SoftAssertStrategy()); // for final action step
-        when(strategy.execute(any(), any(), any(), any())).thenReturn(Status.SUCCESS);
+            .thenReturn(strategy); // for tear down step
+
+        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
+        FinallyAction finallyAction = FinallyAction.Builder.forAction("final", "action name").build();
+        scenarioExecution.registerFinallyAction(finallyAction);
+
+        Reporter reporter = new Reporter();
+        DefaultExecutionEngine sut = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, actionExecutor);
+        StepDefinition stepDefinition = new StepDefinition("name", null, "type", null, null, null, null, null, fakeEnvironment);
+
+        // When
+        Long executionId = sut.execute(stepDefinition, scenarioExecution);
+        assertThat(executionId).isNotNull();
+        StepExecutionReport report = reporter.subscribeOnExecution(executionId).blockingLast();
+        assertThat(report).isNotNull();
+
+        // Then
+        assertThat(scenarioExecution.hasToStop()).isFalse();
+
+        assertThat(report.steps).hasSize(1);
+        assertThat(report.environment).isEqualTo(fakeEnvironment);
+        StepExecutionReport tearDownRootNode = report.steps.get(0);
+        assertThat(tearDownRootNode.name).isEqualTo(tearDownRootNodeName);
+        assertThat(tearDownRootNode.strategy).isEqualTo(new SoftAssertStrategy().getType());
+        assertThat(tearDownRootNode.environment).isEqualTo(fakeEnvironment);
+        assertThat(tearDownRootNode.steps).hasSize(1);
+        assertThat(tearDownRootNode.steps.get(0).name).isEqualTo(finallyAction.name());
+        assertThat(tearDownRootNode.steps.get(0).type).isEqualTo(finallyAction.type());
+        assertThat(tearDownRootNode.steps.get(0).environment).isEqualTo(fakeEnvironment);
+    }
+
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("execution_throwable")
+    void protect_tear_down_execution_by_fault_barrier_unless_vm_error(Supplier<Throwable> throwable) {
+        // Given
+        StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
+        when(strategy.execute(any(), any(), any(), any()))
+            .thenReturn(Status.SUCCESS) // for step definition
+            .thenThrow(throwable.get()); // for tear down step
+        when(stepExecutionStrategies.buildStrategyFrom(any()))
+            .thenReturn(strategy) // for step definition
+            .thenReturn(strategy); // for tear down step
+
+        Reporter reporter = new Reporter();
+        DefaultExecutionEngine sut = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, actionExecutor);
+        StepDefinition stepDefinition = new StepDefinition("name", null, "type", null, null, null, null, null, fakeEnvironment);
+
+        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
+        FinallyAction finallyAction = FinallyAction.Builder.forAction("final", "action name").build();
+        scenarioExecution.registerFinallyAction(finallyAction);
+
+        // When
+        Long executionId = sut.execute(stepDefinition, scenarioExecution);
+        StepExecutionReport report = reporter.subscribeOnExecution(executionId).blockingLast();
+
+        // Then
+        assertThat(scenarioExecution.hasToStop()).isFalse();
+
+        if (throwable.get() instanceof VirtualMachineError) {
+            assertThat(report.status).isEqualTo(Status.NOT_EXECUTED);
+            assertThat(report.errors).hasSize(0);
+        } else {
+            assertThat(report.status).isEqualTo(Status.FAILURE);
+            assertThat(report.errors).hasSize(0);
+            assertThat(report.steps).hasSize(1);
+            StepExecutionReport tearDownRootNode = report.steps.get(0);
+            assertThat(tearDownRootNode.name).isEqualTo(tearDownRootNodeName);
+            assertThat(tearDownRootNode.status).isEqualTo(Status.FAILURE);
+            assertThat(tearDownRootNode.errors).hasSize(1);
+            assertThat(tearDownRootNode.errors.get(0)).isEqualTo(throwableToCatchMessage);
+        }
+    }
+
+    @Test
+    public void execute_tear_down_steps_in_declaration_order() {
+        // Given
+        Reporter reporter = new Reporter();
+        DefaultExecutionEngine sut = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, actionExecutor);
+
+        StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
+        when(strategy.execute(any(), any(), any(), any()))
+            .thenReturn(Status.SUCCESS) // for step definition
+            .thenReturn(Status.SUCCESS); // for tear down step
+        when(stepExecutionStrategies.buildStrategyFrom(any()))
+            .thenReturn(strategy) // for step definition
+            .thenReturn(strategy); // for tear down step
 
         StepDefinition stepDefinition = new StepDefinition("name", null, "type", null, null, null, null, null, fakeEnvironment);
 
         ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
 
-        Map<String, Object> entries1 = Map.of("key1", "value1");
-        Map<String, Object> entries2 = Map.of("key2", "value2");
-        FinallyAction first = FinallyAction.Builder.forAction("context-put", "first").withInput("entries", entries1).build();
-        FinallyAction second = FinallyAction.Builder.forAction("failure", "second").build();
-        FinallyAction third = FinallyAction.Builder.forAction("context-put", "third").withInput("entries", entries2).build();
-        scenarioExecution.registerFinallyAction(first);
-        scenarioExecution.registerFinallyAction(second);
-        scenarioExecution.registerFinallyAction(third);
-
-        List<BeginStepExecutionEvent> events = new ArrayList<>();
-        getInstance().registerOnExecutionId(BeginStepExecutionEvent.class, scenarioExecution.executionId, e -> events.add((BeginStepExecutionEvent) e));
+        Map<String, Object> inputs1 = Map.of("key1", "value1");
+        Map<String, Object> inputs2 = Map.of("key2", "value2");
+        FinallyAction tearDownFirstAction = FinallyAction.Builder.forAction("action-type-1", "teardown first action").withInput("entries", inputs1).build();
+        FinallyAction tearDownSecondAction = FinallyAction.Builder.forAction("action-type-2", "teardown second action").build();
+        FinallyAction tearDownThirdAction = FinallyAction.Builder.forAction("action-type-3", "teardown third action").withInput("entries", inputs2).build();
+        scenarioExecution.registerFinallyAction(tearDownFirstAction);
+        scenarioExecution.registerFinallyAction(tearDownSecondAction);
+        scenarioExecution.registerFinallyAction(tearDownThirdAction);
 
         // When
-        engineUnderTest.execute(stepDefinition, scenarioExecution);
-        reporter.subscribeOnExecution(scenarioExecution.executionId).blockingLast();
-        await().until(() -> events.size() == 4);
+        Long executionId = sut.execute(stepDefinition, scenarioExecution);
+        StepExecutionReport report = reporter.subscribeOnExecution(executionId).blockingLast();
 
         // Then
         //Test order is reversed
-        Step finalStep = events.get(0).step;
-        Step firstStep = events.get(1).step;
-        Step secondStep = events.get(2).step;
-        Step thirdStep = events.get(3).step;
+        assertThat(report.status).isEqualTo(Status.NOT_EXECUTED);
+        assertThat(report.steps).hasSize(1);
+        StepExecutionReport tearDownRootNode = report.steps.get(0);
+        assertThat(tearDownRootNode.name).isEqualTo(tearDownRootNodeName);
 
-        assertThat(finalStep.isParentStep()).isTrue();
+        assertThat(tearDownRootNode.steps).hasSize(3);
+        StepExecutionReport tearDownFirstActionReport = tearDownRootNode.steps.get(0);
+        StepExecutionReport tearDownSecondActionReport = tearDownRootNode.steps.get(1);
+        StepExecutionReport tearDownThirdActionReport = tearDownRootNode.steps.get(2);
 
-        assertThat(thirdStep.type()).isEqualTo("context-put");
-        Map<String, Object> e1 = (Map<String, Object>) thirdStep.definition().inputs().get("entries");
-        assertThat(e1).containsAllEntriesOf(entries2);
-
-        assertThat(secondStep.type()).isEqualTo("failure");
-
-        assertThat(firstStep.type()).isEqualTo("context-put");
-        Map<String, Object> e2 = (Map<String, Object>) firstStep.definition().inputs().get("entries");
-        assertThat(e2).containsAllEntriesOf(entries1);
+        assertThat(tearDownFirstActionReport.name).isEqualTo(tearDownFirstAction.name());
+        assertThat(tearDownFirstActionReport.type).isEqualTo(tearDownFirstAction.type());
+        assertThat(tearDownSecondActionReport.name).isEqualTo(tearDownSecondAction.name());
+        assertThat(tearDownSecondActionReport.type).isEqualTo(tearDownSecondAction.type());
+        assertThat(tearDownThirdActionReport.name).isEqualTo(tearDownThirdAction.name());
+        assertThat(tearDownThirdActionReport.type).isEqualTo(tearDownThirdAction.type());
     }
 
-    @Test
-    public void should_add_finally_actions_to_root_step() {
-        Reporter reporter = new Reporter();
-        DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter, actionExecutor);
-
-        StepExecutionStrategy strategy = mock(StepExecutionStrategy.class);
-        when(stepExecutionStrategies.buildStrategyFrom(any())).thenReturn(strategy);
-        when(strategy.execute(any(), any(), any(), any())).thenReturn(Status.SUCCESS);
-
-        StepDefinition stepDefinition = new StepDefinition("name", null, "type", null, null, null, null, null, fakeEnvironment);
-
-        ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution(null);
-
-        FinallyAction finallyAction = FinallyAction.Builder.forAction("final", "finalActionName").build();
-        scenarioExecution.registerFinallyAction(finallyAction);
-
-        AtomicReference<EndScenarioExecutionEvent> endEvent = new AtomicReference<>();
-        getInstance().registerOnExecutionId(EndScenarioExecutionEvent.class, scenarioExecution.executionId, e -> endEvent.set((EndScenarioExecutionEvent) e));
-
-        // When
-        engineUnderTest.execute(stepDefinition, scenarioExecution);
-        reporter.subscribeOnExecution(scenarioExecution.executionId).blockingLast();
-        await().untilAtomic(endEvent, notNullValue());
-
-        // Then
-        Step rootStep = endEvent.get().step;
-        assertThat(rootStep.subSteps().size()).isEqualTo(1);
-        assertThat(rootStep.subSteps().get(0).definition().name).isEqualTo("TearDown");
-        assertThat(rootStep.subSteps().get(0).definition().environment).isEqualTo(fakeEnvironment);
-        assertThat(rootStep.subSteps().get(0).definition().steps.size()).isEqualTo(1);
-        assertThat(rootStep.subSteps().get(0).definition().steps.get(0).name).isEqualTo(finallyAction.name());
-        assertThat(rootStep.subSteps().get(0).definition().steps.get(0).environment).isEqualTo(fakeEnvironment);
-    }
-
-    private static Stream<Arguments> throwable_caught_by_fault_barrier() {
+    private static Stream<Arguments> execution_throwable() {
         return Stream.of(
-            Arguments.of(Named.of("RuntimeException", (Supplier<Throwable>) () -> new RuntimeException(throwableMessage))),
-            Arguments.of(Named.of("NoClassDefFoundError", (Supplier<Throwable>) () -> new NoClassDefFoundError(throwableMessage))),
-            Arguments.of(Named.of("NoSuchMethodError", (Supplier<Throwable>) () -> new NoSuchMethodError(throwableMessage)))
+            Arguments.of(Named.of("RuntimeException", (Supplier<Throwable>) () -> new RuntimeException(throwableToCatchMessage))),
+            Arguments.of(Named.of("NoClassDefFoundError", (Supplier<Throwable>) () -> new NoClassDefFoundError(throwableToCatchMessage))),
+            Arguments.of(Named.of("NoSuchMethodError", (Supplier<Throwable>) () -> new NoSuchMethodError(throwableToCatchMessage))),
+            Arguments.of(Named.of("Error", (Supplier<Throwable>) () -> new Error(throwableToCatchMessage))),
+            Arguments.of(Named.of("OutOfMemoryError", (Supplier<Throwable>) () -> new OutOfMemoryError(throwableToNotCatchMessage))),
+            Arguments.of(Named.of("StackOverflowError", (Supplier<Throwable>) () -> new StackOverflowError(throwableToNotCatchMessage)))
         );
     }
 }


### PR DESCRIPTION
#### Describe the changes you've made

Extend Chutney engine scenario execution fault barrier to catch all Throwable but VM Errors.

#### Checklist

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
