### PR TITLE
feat(sql): Getting result by headers is non sensitive

### DIFF
--- a/action-impl/src/main/java/com/chutneytesting/action/sql/core/Column.java
+++ b/action-impl/src/main/java/com/chutneytesting/action/sql/core/Column.java
@@ -17,6 +17,10 @@ public class Column {
         return this.name;
     }
 
+    public boolean hasName(String name) {
+        return this.name.trim().equalsIgnoreCase(name.trim());
+    }
+
     public String printHeader(int length) {
         return name + " ".repeat(length - name.length());
     }
@@ -27,7 +31,7 @@ public class Column {
         if (o == null || getClass() != o.getClass()) return false;
         Column column = (Column) o;
         return index == column.index &&
-            Objects.equals(name, column.name);
+            column.hasName(name);
     }
 
     @Override

--- a/action-impl/src/main/java/com/chutneytesting/action/sql/core/Row.java
+++ b/action-impl/src/main/java/com/chutneytesting/action/sql/core/Row.java
@@ -16,7 +16,7 @@ public class Row {
 
     public Object get(Column column) {
         return cells.stream()
-            .filter(v -> v.column.equals(column))
+            .filter(c -> c.column.equals(column))
             .findFirst()
             .orElse(Cell.NONE)
             .value;
@@ -24,7 +24,7 @@ public class Row {
 
     public Object get(String header) {
         return cells.stream()
-            .filter(v -> v.column.name.equals(header))
+            .filter(c -> c.column.hasName(header))
             .findFirst()
             .orElse(Cell.NONE)
             .value;
@@ -32,7 +32,7 @@ public class Row {
 
     public Object get(int index) {
         return cells.stream()
-            .filter(v -> v.column.index == index)
+            .filter(c -> c.column.index == index)
             .findFirst()
             .orElse(Cell.NONE)
             .value;

--- a/action-impl/src/test/java/com/chutneytesting/action/sql/SqlActionTest.java
+++ b/action-impl/src/test/java/com/chutneytesting/action/sql/SqlActionTest.java
@@ -51,7 +51,7 @@ public class SqlActionTest {
     }
 
     @Test
-    public void should_output_only_on_result_when_single_statement() {
+    public void should_output_only_one_result_when_single_statement() {
         // Given
         ActionsConfiguration configuration = new TestActionsConfiguration();
         Action action = new SqlAction(sqlTarget, logger, configuration, Collections.singletonList("select * from users"), 2);
@@ -124,5 +124,22 @@ public class SqlActionTest {
             "|----|---------|-----------------|\n" +
             "| 2  | carotte | kakarot@fake.db |\n"
         );
+    }
+
+    @Test
+    public void should_be_non_sensitive_to_header_case_or_spaces() {
+        // Given
+        ActionsConfiguration configuration = new TestActionsConfiguration();
+        Action action = new SqlAction(sqlTarget, logger, configuration, Lists.newArrayList("select * from users"), 2);
+
+        // When
+        ActionExecutionResult result = action.execute();
+
+        // Then
+        Rows rows = (Rows) result.outputs.get("rows");
+
+        assertThat(rows.get("id")).isEqualTo(List.of(1,2,3));
+        assertThat(rows.get("NaMe")).isEqualTo(List.of("laitue","carotte", "tomate"));
+        assertThat(rows.get(" EMAIL ")).isEqualTo(List.of("laitue@fake.com","kakarot@fake.db","null"));
     }
 }

--- a/action-impl/src/test/java/com/chutneytesting/action/sql/core/RecordsTest.java
+++ b/action-impl/src/test/java/com/chutneytesting/action/sql/core/RecordsTest.java
@@ -20,9 +20,9 @@ public class RecordsTest {
         Column c3 = new Column("Number", 3);
         Column c4 = new Column("Number", 4);
 
-        Records actual = new Records(-1, List.of(c0, c1, c2, c3, c4), emptyList());
+        Records sut = new Records(-1, List.of(c0, c1, c2, c3, c4), emptyList());
 
-        assertThat(actual.getHeaders()).isEqualTo(List.of("Test", "Letter", "Letter", "Number", "Number"));
+        assertThat(sut.getHeaders()).isEqualTo(List.of("Test", "Letter", "Letter", "Number", "Number"));
     }
 
     @Test
@@ -34,10 +34,10 @@ public class RecordsTest {
             new Row(List.of(new Cell(fake, "AA"), new Cell(fake, "BB")))
         );
 
-        Records actual = new Records(-1, emptyList(), records);
+        Records sut = new Records(-1, emptyList(), records);
 
-        assertThat(actual.getRows().get(0)).isEqualTo(List.of("A", "B"));
-        assertThat(actual.getRows().get(1)).isEqualTo(List.of("AA", "BB"));
+        assertThat(sut.getRows().get(0)).isEqualTo(List.of("A", "B"));
+        assertThat(sut.getRows().get(1)).isEqualTo(List.of("AA", "BB"));
     }
 
     @Test


### PR DESCRIPTION
#### Describe the changes you've made

Ignore case and leading or trailing white spaces  when getting result values by the column/header name.

#### Checklist

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
