### PR TITLE
tech(engine): Put env in context once for all steps

### DIFF
--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
@@ -64,6 +64,8 @@ public class DefaultExecutionEngine implements ExecutionEngine {
         actionExecutor.execute(() -> {
 
             final ScenarioContext scenarioContext = new ScenarioContextImpl();
+            scenarioContext.put("environment", stepDefinition.environment);
+
             try {
                 try {
                     rootStep.set(buildStep(stepDefinition));

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/scenario/ScenarioContext.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/scenario/ScenarioContext.java
@@ -24,7 +24,7 @@ public interface ScenarioContext extends Map<String, Object> {
 
         public int size() {return scenarioContext.size();}
         public boolean isEmpty() {return scenarioContext.isEmpty();}
-        public boolean containsKey(Object key) {return false;}
+        public boolean containsKey(Object key) {return scenarioContext.containsKey(key);}
         public boolean containsValue(Object value) {return scenarioContext.containsValue(value);}
         public Object get(Object key) {return scenarioContext.get(key);}
 

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
@@ -82,7 +82,6 @@ public class Step {
 
         try {
             makeTargetAccessibleForInputEvaluation(scenarioContext);
-            makeEnvironmentAccessibleForInputEvaluation(scenarioContext);
 
             final Map<String, Object> evaluatedInputs = definition.type.equals("final") ? definition.inputs() : unmodifiableMap(dataEvaluator.evaluateNamedDataWithContextVariables(definition.inputs(), scenarioContext));
             target = dataEvaluator.evaluateTarget(target, scenarioContext);
@@ -231,10 +230,6 @@ public class Step {
 
     private void makeTargetAccessibleForInputEvaluation(ScenarioContext scenarioContext) {
         scenarioContext.put("target", target);
-    }
-
-    private void makeEnvironmentAccessibleForInputEvaluation(ScenarioContext scenarioContext) {
-        scenarioContext.put("environment", definition.environment);
     }
 
     private void copyStepResultsToScenarioContext(StepContextImpl stepContext, ScenarioContext scenarioContext) {

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/step/StepTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/step/StepTest.java
@@ -231,14 +231,12 @@ public class StepTest {
     }
 
     @Test
-    public void target_and_environment_are_set_in_scenario_context_in_order_to_be_used_by_evaluated_inputs() {
+    public void target_is_set_in_scenario_context_in_order_to_be_used_by_evaluated_inputs() {
         // Given
         TargetImpl fakeTarget = TargetImpl.builder().withName("fakeTargetName").build();
-        String environment = "FakeTestEnvironment";
 
         Map<String, Object> inputs = new HashMap<>();
         inputs.put("targetName", "${#target.name}");
-        inputs.put("currentEnvironment", "${#environment}");
 
         StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "actionType", null, inputs, null, null, null, environment);
         Step step = new Step(dataEvaluator, fakeStepDefinition, mock(StepExecutor.class), emptyList());
@@ -248,11 +246,9 @@ public class StepTest {
 
         // Then
         StepContext context = step.stepContext();
-        assertThat(context.getEvaluatedInputs()).hasSize(2);
+        assertThat(context.getEvaluatedInputs()).hasSize(1);
         assertThat(context.getEvaluatedInputs()).containsKeys("targetName");
         assertThat(context.getEvaluatedInputs().get("targetName")).isEqualTo("fakeTargetName");
-        assertThat(context.getEvaluatedInputs()).containsKeys("currentEnvironment");
-        assertThat(context.getEvaluatedInputs().get("currentEnvironment")).isEqualTo(environment);
     }
 
     @Test


### PR DESCRIPTION
#### Describe the changes you've made

Environment name was put in context for every step execution, while it is the same during all execution, so it only needs to be done once.

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
