### PR TITLE
feat(server): include private and package-only fields in SqlAction ou…

### DIFF
--- a/action-impl/src/main/java/com/chutneytesting/action/sql/core/Row.java
+++ b/action-impl/src/main/java/com/chutneytesting/action/sql/core/Row.java
@@ -2,12 +2,14 @@ package com.chutneytesting.action.sql.core;
 
 import static java.util.stream.Collectors.toMap;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 public class Row {
+    @JsonProperty
     final List<Cell> cells;
 
     public Row(List<Cell> values) {

--- a/action-impl/src/main/java/com/chutneytesting/action/sql/core/Rows.java
+++ b/action-impl/src/main/java/com/chutneytesting/action/sql/core/Rows.java
@@ -2,6 +2,7 @@ package com.chutneytesting.action.sql.core;
 
 import static java.util.stream.Collectors.toList;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Map;
 
 public class Rows {
 
+    @JsonProperty
     private final List<Row> rows;
 
     public Rows(List<Row> rows) {

--- a/server/src/test/resources/blackbox/actions/sql.feature
+++ b/server/src/test/resources/blackbox/actions/sql.feature
@@ -81,7 +81,22 @@ Feature: SQL Task test
         And the report contains record results
             Do compare
                 With actual ${#json(#report, "$.report.steps[-1:].stepOutputs.recordResult").toString()}
-                With expected [[{"affectedRows":"-1","headers":["ID","NAME","EMAIL"],"rows":[["1","laitue","laitue@fake.com"],["2","carotte","kakarot@fake.db"]],"columns":[{"name":"ID","index":"0"},{"name":"NAME","index":"1"},{"name":"EMAIL","index":"2"}],"records":[{},{}]}]]
+                With expected [[{"affectedRows":"-1","headers":["ID","NAME","EMAIL"],"rows":[["1","laitue","laitue@fake.com"],["2","carotte","kakarot@fake.db"]],"columns":[{"name":"ID","index":"0"},{"name":"NAME","index":"1"},{"name":"EMAIL","index":"2"}],"records":[{"cells":[{"column":{"name":"ID","index":"0"},"value":"1"},{"column":{"name":"NAME","index":"1"},"value":"laitue"},{"column":{"name":"EMAIL","index":"2"},"value":"laitue@fake.com"}]},{"cells":[{"column":{"name":"ID","index":"0"},"value":"2"},{"column":{"name":"NAME","index":"1"},"value":"carotte"},{"column":{"name":"EMAIL","index":"2"},"value":"kakarot@fake.db"}]}]}]]
+                With mode equals
+        And the report contains firstRow output
+            Do compare
+                With actual ${#json(#report, "$.report.steps[-1:].stepOutputs.firstRow").toString()}
+                With expected [{"cells":[{"column":{"name":"ID","index":"0"},"value":"1"},{"column":{"name":"NAME","index":"1"},"value":"laitue"},{"column":{"name":"EMAIL","index":"2"},"value":"laitue@fake.com"}]}]
+                With mode equals
+        And the report contains rows output
+            Do compare
+                With actual ${#json(#report, "$.report.steps[-1:].stepOutputs.rows").toString()}
+                With expected [{"rows":[{"cells":[{"column":{"name":"ID","index":"0"},"value":"1"},{"column":{"name":"NAME","index":"1"},"value":"laitue"},{"column":{"name":"EMAIL","index":"2"},"value":"laitue@fake.com"}]},{"cells":[{"column":{"name":"ID","index":"0"},"value":"2"},{"column":{"name":"NAME","index":"1"},"value":"carotte"},{"column":{"name":"EMAIL","index":"2"},"value":"kakarot@fake.db"}]}]}]
+                With mode equals
+        And the report contains affectedRows output
+            Do compare
+                With actual ${#json(#report, "$.report.steps[-1:].stepOutputs.affectedRows").toString()}
+                With expected ["-1"]
                 With mode equals
 
     Scenario: Sql query wrong table


### PR DESCRIPTION
…tput serialization

#### Issue Number
fixes #
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->
`firstRow `and `rows ` outputs in sql action are empty.
#### Describe the changes you've made
Include private and package-only fields in SqlAction output serialization.
Jackson ObjetMapper doesn't include non public attributes by default.
<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
