### PR TITLE
feature(scenario execution): show not executed scenario when campain stop

### DIFF
--- a/server-core/src/main/java/com/chutneytesting/server/core/domain/execution/ScenarioExecutionEngine.java
+++ b/server-core/src/main/java/com/chutneytesting/server/core/domain/execution/ScenarioExecutionEngine.java
@@ -44,7 +44,4 @@ public class ScenarioExecutionEngine {
         return executionEngineAsync.saveNotExecutedScenarioExecution(executionRequest);
     }
 
-    public void saveNotExecutedScenarioReport(ExecutionRequest executionRequest, Long executionId) {
-        executionEngineAsync.saveNotExecutedScenarioReport(executionRequest, executionId);
-    }
 }

--- a/server-core/src/main/java/com/chutneytesting/server/core/domain/execution/ScenarioExecutionEngine.java
+++ b/server-core/src/main/java/com/chutneytesting/server/core/domain/execution/ScenarioExecutionEngine.java
@@ -1,5 +1,6 @@
 package com.chutneytesting.server.core.domain.execution;
 
+import com.chutneytesting.server.core.domain.execution.history.ExecutionHistory;
 import com.chutneytesting.server.core.domain.execution.processor.TestCasePreProcessors;
 import com.chutneytesting.server.core.domain.execution.report.ScenarioExecutionReport;
 import com.chutneytesting.server.core.domain.execution.report.StepExecutionReportCore;
@@ -37,5 +38,13 @@ public class ScenarioExecutionEngine {
 
         StepExecutionReportCore finalStepReport = executionEngine.execute(processedExecutionRequest);
         return new ScenarioExecutionReport(0L, processedExecutionRequest.testCase.metadata().title(), executionRequest.environment, executionRequest.userId, finalStepReport);
+    }
+
+    public ExecutionHistory.Execution saveNotExecutedScenarioExecution(ExecutionRequest executionRequest) {
+        return executionEngineAsync.saveNotExecutedScenarioExecution(executionRequest);
+    }
+
+    public void saveNotExecutedScenarioReport(ExecutionRequest executionRequest, Long executionId) {
+        executionEngineAsync.saveNotExecutedScenarioReport(executionRequest, executionId);
     }
 }

--- a/server-core/src/main/java/com/chutneytesting/server/core/domain/execution/ScenarioExecutionEngineAsync.java
+++ b/server-core/src/main/java/com/chutneytesting/server/core/domain/execution/ScenarioExecutionEngineAsync.java
@@ -19,6 +19,7 @@ import com.google.common.base.Ascii;
 import com.google.common.base.Joiner;
 import io.reactivex.Completable;
 import io.reactivex.Observable;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -204,6 +205,44 @@ public class ScenarioExecutionEngineAsync {
 
     public void setDebounceMilliSeconds(long debounceMilliSeconds) {
         this.debounceMilliSeconds = debounceMilliSeconds;
+    }
+
+    public void saveNotExecutedScenarioReport(ExecutionRequest executionRequest, Long executionId) {
+        StepExecutionReportCore report = new StepExecutionReportCore(
+            executionRequest.testCase.metadata().title(),
+            0L,
+            Instant.now(),
+            ServerReportStatus.NOT_EXECUTED,
+            List.of(),
+            List.of(),
+            List.of(),
+            null,
+            null,
+            null,
+            null
+        );
+        ScenarioExecutionReport scenarioExecutionReport =  new ScenarioExecutionReport(
+            executionId,
+            executionRequest.testCase.metadata().title(),
+            executionRequest.environment, executionRequest.userId,
+            report);
+        updateHistory(executionId, executionRequest, scenarioExecutionReport);
+    }
+
+    public ExecutionHistory.Execution saveNotExecutedScenarioExecution(ExecutionRequest executionRequest) {
+        ExecutionHistory.DetachedExecution detachedExecution = ImmutableExecutionHistory.DetachedExecution.builder()
+            .time(LocalDateTime.now())
+            .duration(0L)
+            .status(ServerReportStatus.NOT_EXECUTED)
+            .info("")
+            .error("")
+            .report("")
+            .testCaseTitle(executionRequest.testCase.metadata().title())
+            .environment(executionRequest.environment)
+            .user(executionRequest.userId)
+            .build();
+
+        return executionHistoryRepository.store(executionRequest.testCase.id(), detachedExecution);
     }
 
     /**

--- a/server/src/main/java/com/chutneytesting/execution/domain/campaign/CampaignExecutionEngine.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/campaign/CampaignExecutionEngine.java
@@ -206,13 +206,13 @@ public class CampaignExecutionEngine {
                 // Init scenario execution in campaign report
                 campaignExecutionReport.startScenarioExecution(testCase, campaign.executionEnvironment(), campaignExecutionReport.userId);
                 // Execute scenario
-                ScenarioExecutionReportCampaign scenarioExecutionReport = executeScenario(campaign, testCase, campaignExecutionReport);
+                scenarioExecutionReport = executeScenario(campaign, testCase, campaignExecutionReport);
                 // Retry one time if failed
                 if (campaign.retryAuto && ServerReportStatus.FAILURE.equals(scenarioExecutionReport.status())) {
                     scenarioExecutionReport = executeScenario(campaign, testCase, campaignExecutionReport);
                 }
             } else {
-                scenarioExecutionReport = generateNotExecutedScenarioExecutionAndReport(campaign, testCase, campaignExecutionReport.userId);
+                scenarioExecutionReport = generateNotExecutedScenarioExecutionAndReport(campaign, testCase, campaignExecutionReport);
             }
                 // Add scenario report to campaign's one
             ofNullable(scenarioExecutionReport)
@@ -225,10 +225,9 @@ public class CampaignExecutionEngine {
         };
     }
 
-    private ScenarioExecutionReportCampaign generateNotExecutedScenarioExecutionAndReport(Campaign campaign, TestCase testCase, String userId) {
-        ExecutionRequest executionRequest = buildExecutionRequest(campaign, testCase, userId);
+    private ScenarioExecutionReportCampaign generateNotExecutedScenarioExecutionAndReport(Campaign campaign, TestCase testCase, CampaignExecutionReport campaignExecutionReport) {
+        ExecutionRequest executionRequest = buildExecutionRequest(campaign, testCase, campaignExecutionReport);
         ExecutionHistory.Execution execution = scenarioExecutionEngine.saveNotExecutedScenarioExecution(executionRequest);
-        scenarioExecutionEngine.saveNotExecutedScenarioReport(executionRequest, execution.executionId());
         return new ScenarioExecutionReportCampaign(testCase.id(), testCase.metadata().title(), execution.summary());
     }
 

--- a/server/src/main/java/com/chutneytesting/execution/domain/campaign/CampaignExecutionEngine.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/campaign/CampaignExecutionEngine.java
@@ -200,6 +200,7 @@ public class CampaignExecutionEngine {
 
     private Consumer<TestCase> executeScenarioInCampaign(Campaign campaign, CampaignExecutionReport campaignExecutionReport) {
         return testCase -> {
+            ScenarioExecutionReportCampaign scenarioExecutionReport;
             // Is stop requested ?
             if (!currentCampaignExecutionsStopRequests.get(campaignExecutionReport.executionId)) {
                 // Init scenario execution in campaign report
@@ -210,17 +211,27 @@ public class CampaignExecutionEngine {
                 if (campaign.retryAuto && ServerReportStatus.FAILURE.equals(scenarioExecutionReport.status())) {
                     scenarioExecutionReport = executeScenario(campaign, testCase, campaignExecutionReport);
                 }
-                // Add scenario report to campaign's one
-                ofNullable(scenarioExecutionReport)
-                    .ifPresent(serc -> {
-                        campaignExecutionReport.endScenarioExecution(serc);
-                        // update xray test
-                        ExecutionHistory.Execution execution = executionHistoryRepository.getExecution(serc.scenarioId, serc.execution.executionId());
-                        jiraXrayEmbeddedApi.updateTestExecution(campaign.id, campaignExecutionReport.executionId, serc.scenarioId, JiraReportMapper.from(execution.report(), objectMapper));
-                    });
+            } else {
+                scenarioExecutionReport = generateNotExecutedScenarioExecutionAndReport(campaign, testCase, campaignExecutionReport.userId);
             }
+                // Add scenario report to campaign's one
+            ofNullable(scenarioExecutionReport)
+                .ifPresent(serc -> {
+                    campaignExecutionReport.endScenarioExecution(serc);
+                    // update xray test
+                    ExecutionHistory.Execution execution = executionHistoryRepository.getExecution(serc.scenarioId, serc.execution.executionId());
+                    jiraXrayEmbeddedApi.updateTestExecution(campaign.id, campaignExecutionReport.executionId, serc.scenarioId, JiraReportMapper.from(execution.report(), objectMapper));
+                });
         };
     }
+
+    private ScenarioExecutionReportCampaign generateNotExecutedScenarioExecutionAndReport(Campaign campaign, TestCase testCase, String userId) {
+        ExecutionRequest executionRequest = buildExecutionRequest(campaign, testCase, userId);
+        ExecutionHistory.Execution execution = scenarioExecutionEngine.saveNotExecutedScenarioExecution(executionRequest);
+        scenarioExecutionEngine.saveNotExecutedScenarioReport(executionRequest, execution.executionId());
+        return new ScenarioExecutionReportCampaign(testCase.id(), testCase.metadata().title(), execution.summary());
+    }
+
 
     private ScenarioExecutionReportCampaign executeScenario(Campaign campaign, TestCase testCase, CampaignExecutionReport campaignExecutionReport) {
         Long executionId;


### PR DESCRIPTION
show not executed scenario when campain stop

#### Issue Number
fixes #1092 
<!-- Please Mention the issue number as #(Issue Number) Example: #5 -->

#### Describe the changes you've made

Save not executed scenario execution
<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->
NA
<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [x] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
