### PR TITLE
fix(ui): fix navigation in empty dataset

### DIFF
--- a/ui/src/app/modules/dataset/components/dataset-edition/forms-data-grid/forms-data-grid.component.html
+++ b/ui/src/app/modules/dataset/components/dataset-edition/forms-data-grid/forms-data-grid.component.html
@@ -42,7 +42,7 @@
             <tbody>
             <tr *ngFor="let line of dataGridForm.controls; let i = index">
                 <td style="width:30px">
-                    <button type="button" class="btn btn-outline-danger delete-button-height" (click)="removeLine(i)"
+                    <button tabindex="-1" type="button" class="btn btn-outline-danger delete-button-height" (click)="removeLine(i)"
                             title="{{'global.actions.delete' | translate}}">
                         <span class="fa fa-times"></span>
                     </button>

--- a/ui/src/app/modules/dataset/components/dataset-edition/forms-data-grid/forms-data-grid.component.html
+++ b/ui/src/app/modules/dataset/components/dataset-edition/forms-data-grid/forms-data-grid.component.html
@@ -26,15 +26,15 @@
                 <th style="width:30px">
                 </th>
                 <th class="header index-col">#</th>
-                <th class="header" scope="col" *ngFor="let header of headers; let i = index" style="min-width:250px ">
+                <th class="header" scope="col" *ngFor="let header of headers.controls; let i = index;" style="min-width:250px ">
                     <div style="text-align: center; margin-bottom: 2px;">
-                        <button type="button" class="btn btn-outline-danger delete-button-height removeBtn"
+                        <button tabindex="-1" type="button" class="btn btn-outline-danger delete-button-height removeBtn"
                                 (click)="removeColumn(i)"
                                 title="{{'global.actions.delete' | translate}}">
                             <span class="fa fa-times"></span>
                         </button>
                     </div>
-                    <input type="text" class="form-control" id="{{i}}-header" placeholder="{{ 'global.smallword.key' | translate }}" value="{{header}}"
+                    <input type="text" class="form-control" id="{{i}}-header" placeholder="{{ 'global.smallword.key' | translate }}" [formControl]="header"
                            (change)="updateHeader(i, $event.target.value)"/>
                 </th>
             </tr>


### PR DESCRIPTION
#### fixes 
#1106
The bug can be reproduced [here](https://stackblitz.com/edit/stackblitz-starters-rzecue?file=src%2Fmain.ts)
#### Describe the changes you've made
The problem occures:
- inside ngFor
-  and when having multiple inputs with the same  string [value]. (May be a problem of memory reference ?)
- and when trying to update the iteration variable

**Solution**:
Avoid to update iteration string variable inside ngFor. So use FormArray instead of String[].
<!-- A clear and concise description of what you have done to successfully close the issue.
Any new files? or anything you feel to let us know! -->

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

<!-- A clear and concise description of it. -->

#### Additional context <!-- OPTIONAL -->

<!-- Add any other context or screenshots about the feature request here -->

#### Test plan <!-- OPTIONAL -->

<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [x] No git conflict
