### PR TITLE
Fix/evaluate dataset content

### DIFF
--- a/component/src/test/java/com/chutneytesting/component/dataset/infra/DataSetPatchUtilsTest.java
+++ b/component/src/test/java/com/chutneytesting/component/dataset/infra/DataSetPatchUtilsTest.java
@@ -93,7 +93,7 @@ public class DataSetPatchUtilsTest {
     public void should_create_then_apply_diff() throws PatchFailedException {
         // Given
         String original = "p1 | value1\n" +
-            "pouetpouet | v2\n" +
+            "checkcheck | v2\n" +
             "\n" +
             "| p3 | param4 |\n" +
             "| v31 | value41 |\n" +

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
@@ -97,10 +97,9 @@ public class DefaultExecutionEngine implements ExecutionEngine {
     }
 
     private Map<String, ?> evaluateDatasetConstants(Dataset dataset, ScenarioContext scenarioContext) {
-        Map<String, ?> evaluatedConstants = dataset.constants.entrySet().stream()
+        return dataset.constants.entrySet().stream()
             .map(e -> Map.entry(e.getKey(), dataEvaluator.evaluate(e.getValue(), scenarioContext)))
             .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
-        return evaluatedConstants;
     }
 
     private Optional<Step> initFinalRootStep(AtomicReference<Step> rootStep, List<FinallyAction> finallyActionsSnapshot) {

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
@@ -239,7 +239,7 @@ public class Step {
     }
 
     public void updateContextFrom(StepExecutionReport remoteReport) {
-        ActionExecutionResult.Status status =  Status.SUCCESS.equals(remoteReport.status) ? ActionExecutionResult.Status.Success : ActionExecutionResult.Status.Failure;
+        ActionExecutionResult.Status status = Status.SUCCESS.equals(remoteReport.status) ? ActionExecutionResult.Status.Success : ActionExecutionResult.Status.Failure;
         updateContextWith(status, remoteReport.stepResults, emptyList(), emptyList());
     }
 

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/strategies/StepIterationStrategy.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/strategies/StepIterationStrategy.java
@@ -73,7 +73,7 @@ public class StepIterationStrategy implements StepExecutionStrategy {
             .map(iterationData -> iterationData.entrySet().stream()
                 .map(e -> Map.entry(e.getKey(), evaluator.evaluate(e.getValue(), scenarioContext)))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
-            .collect(Collectors.toList());
+            .toList();
         return evaluatedDataset;
     }
 

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/StepIterationStrategyTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/StepIterationStrategyTest.java
@@ -60,13 +60,13 @@ class StepIterationStrategyTest {
         StepExecutionReportDto iteration0 = parentStep.steps.get(0);
         assertThat(iteration0.status).isEqualTo(SUCCESS);
         assertThat(iteration0.name).startsWith("0 -");
-        assertThat(iteration0.information.get(0)).isEqualTo("Validation [pouet_0_ok : ${#pouet_0 == \"/\" + #generatedID + \"/0\"}] : OK");
+        assertThat(iteration0.information.get(0)).isEqualTo("Validation [check_0_ok : ${#check_0 == \"/\" + #generatedID + \"/0\"}] : OK");
         assertDoesNotThrow(() -> UUID.fromString((String) iteration0.context.evaluatedInputs.get("stringParam")));
 
         StepExecutionReportDto iteration1 = parentStep.steps.get(1);
         assertThat(iteration1.status).isEqualTo(SUCCESS);
         assertThat(iteration1.name).startsWith("1 -");
-        assertThat(iteration1.information.get(0)).isEqualTo("Validation [pouet_1_ok : ${#pouet_1 == \"/\" + #generatedID + \"/1\"}] : OK");
+        assertThat(iteration1.information.get(0)).isEqualTo("Validation [check_1_ok : ${#check_1 == \"/\" + #generatedID + \"/1\"}] : OK");
         assertDoesNotThrow(() -> UUID.fromString((String) iteration1.context.evaluatedInputs.get("stringParam")));
     }
 
@@ -83,10 +83,10 @@ class StepIterationStrategyTest {
         StepExecutionReportDto parentStep = result.steps.get(0);
         assertThat(parentStep.steps).hasSize(2);
         assertThat(parentStep.steps.get(0).name).isEqualTo("0 - Hello website on A with user Tata");
-        assertThat(parentStep.steps.get(0).errors).contains("Validation [pouet_0_ok : ${#env == \"B\"}] : KO");
+        assertThat(parentStep.steps.get(0).errors).contains("Validation [check_0_ok : ${#env == \"B\"}] : KO");
         assertThat(parentStep.steps.get(0).status).isEqualTo(StatusDto.FAILURE);
         assertThat(parentStep.steps.get(1).name).isEqualTo("1 - Hello website on B with user Baba");
-        assertThat(parentStep.steps.get(1).information).contains("Validation [pouet_1_ok : ${#env == \"B\"}] : OK");
+        assertThat(parentStep.steps.get(1).information).contains("Validation [check_1_ok : ${#env == \"B\"}] : OK");
         assertThat(parentStep.steps.get(1).status).isEqualTo(SUCCESS);
     }
 

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/StepIterationStrategyTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/StepIterationStrategyTest.java
@@ -1,6 +1,8 @@
 package com.chutneytesting.engine.domain.execution.strategies;
 
+import static com.chutneytesting.engine.api.execution.StatusDto.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.chutneytesting.ExecutionConfiguration;
 import com.chutneytesting.engine.api.execution.ExecutionRequestDto;
@@ -9,6 +11,7 @@ import com.chutneytesting.engine.api.execution.StepExecutionReportDto;
 import com.chutneytesting.engine.api.execution.TestEngine;
 import com.chutneytesting.tools.Jsons;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class StepIterationStrategyTest {
@@ -37,7 +40,34 @@ class StepIterationStrategyTest {
 
         // T
         assertThat(result.steps.get(0).steps).hasSize(2);
-        assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.SUCCESS);
+        assertThat(result).hasFieldOrPropertyWithValue("status", SUCCESS);
+    }
+
+    @Test
+    public void should_evaluate_dataset_before_iterations() {
+        // G
+        final TestEngine testEngine = new ExecutionConfiguration().embeddedTestEngine();
+        ExecutionRequestDto requestDto = Jsons.loadJsonFromClasspath("scenarios_examples/step_iteration_evaluated_dataset.json", ExecutionRequestDto.class);
+
+        // W
+        StepExecutionReportDto result = testEngine.execute(requestDto);
+
+        // T
+        StepExecutionReportDto parentStep = result.steps.get(0);
+        assertThat(parentStep.steps).hasSize(2);
+        assertThat(parentStep.status).isEqualTo(SUCCESS);
+
+        StepExecutionReportDto iteration0 = parentStep.steps.get(0);
+        assertThat(iteration0.status).isEqualTo(SUCCESS);
+        assertThat(iteration0.name).startsWith("0 -");
+        assertThat(iteration0.information.get(0)).isEqualTo("Validation [pouet_0_ok : ${#pouet_0 == \"/\" + #generatedID + \"/0\"}] : OK");
+        assertDoesNotThrow(() -> UUID.fromString((String) iteration0.context.evaluatedInputs.get("stringParam")));
+
+        StepExecutionReportDto iteration1 = parentStep.steps.get(1);
+        assertThat(iteration1.status).isEqualTo(SUCCESS);
+        assertThat(iteration1.name).startsWith("1 -");
+        assertThat(iteration1.information.get(0)).isEqualTo("Validation [pouet_1_ok : ${#pouet_1 == \"/\" + #generatedID + \"/1\"}] : OK");
+        assertDoesNotThrow(() -> UUID.fromString((String) iteration1.context.evaluatedInputs.get("stringParam")));
     }
 
     @Test
@@ -57,7 +87,7 @@ class StepIterationStrategyTest {
         assertThat(parentStep.steps.get(0).status).isEqualTo(StatusDto.FAILURE);
         assertThat(parentStep.steps.get(1).name).isEqualTo("1 - Hello website on B with user Baba");
         assertThat(parentStep.steps.get(1).information).contains("Validation [pouet_1_ok : ${#env == \"B\"}] : OK");
-        assertThat(parentStep.steps.get(1).status).isEqualTo(StatusDto.SUCCESS);
+        assertThat(parentStep.steps.get(1).status).isEqualTo(SUCCESS);
     }
 
     @Test
@@ -71,7 +101,7 @@ class StepIterationStrategyTest {
 
         // T
         assertThat(result.steps.get(1).steps).hasSize(2);
-        assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.SUCCESS);
+        assertThat(result).hasFieldOrPropertyWithValue("status", SUCCESS);
     }
 
     @Test
@@ -92,7 +122,7 @@ class StepIterationStrategyTest {
         List<StepExecutionReportDto> softStep = firstIteration.steps.get(0).steps;
         assertThat(softStep).hasSize(2); // soft-assert strategy step has 2 children
         assertThat(softStep.get(0).status).isEqualTo(StatusDto.FAILURE);
-        assertThat(softStep.get(1).status).isEqualTo(StatusDto.SUCCESS);
+        assertThat(softStep.get(1).status).isEqualTo(SUCCESS);
     }
 
 }

--- a/engine/src/test/java/com/chutneytesting/tools/TestFunctions.java
+++ b/engine/src/test/java/com/chutneytesting/tools/TestFunctions.java
@@ -1,0 +1,19 @@
+package com.chutneytesting.tools;
+
+import com.chutneytesting.action.spi.SpelFunction;
+import java.util.Random;
+import java.util.UUID;
+
+public class TestFunctions {
+    private static final Random RANDOM_GENERATOR = new Random();
+
+    @SpelFunction
+    public static String randomID() {
+        return UUID.randomUUID().toString();
+    }
+
+    @SpelFunction
+    public static String randomInt(int bound) {
+        return String.valueOf(RANDOM_GENERATOR.nextInt(bound));
+    }
+}

--- a/engine/src/test/resources/META-INF/extension/chutney.functions
+++ b/engine/src/test/resources/META-INF/extension/chutney.functions
@@ -1,0 +1,1 @@
+com.chutneytesting.tools.TestFunctions

--- a/engine/src/test/resources/scenarios_examples/error_without_dataset_iterations.json
+++ b/engine/src/test/resources/scenarios_examples/error_without_dataset_iterations.json
@@ -9,10 +9,10 @@
                     "stringParam": "/${#env}/${#user}"
                 },
                 "outputs": {
-                    "pouet_<idx>": "${\"/\" + #env + \"/\" + #user + \"/<idx>\"}"
+                    "check_<idx>": "${\"/\" + #env + \"/\" + #user + \"/<idx>\"}"
                 },
                 "validations" : {
-                    "pouet_<idx>_ok": "${#pouet_<idx> == \"/\" + #env + \"/\" + #user + \"/<idx>\"}"
+                    "check_<idx>_ok": "${#check_<idx> == \"/\" + #env + \"/\" + #user + \"/<idx>\"}"
                 },
                 "strategy": {
                     "type": "for",

--- a/engine/src/test/resources/scenarios_examples/simple_step_iterations.json
+++ b/engine/src/test/resources/scenarios_examples/simple_step_iterations.json
@@ -22,10 +22,10 @@
                     "stringParam": "/${#env}/${#user}"
                 },
                 "outputs": {
-                    "pouet_<idx>": "${\"/\" + #env + \"/\" + #user + \"/<idx>\"}"
+                    "check_<idx>": "${\"/\" + #env + \"/\" + #user + \"/<idx>\"}"
                 },
                 "validations" : {
-                    "pouet_<idx>_ok": "${#pouet_<idx> == \"/\" + #env + \"/\" + #user + \"/<idx>\"}"
+                    "check_<idx>_ok": "${#check_<idx> == \"/\" + #env + \"/\" + #user + \"/<idx>\"}"
                 },
                 "strategy": {
                     "type": "for",

--- a/engine/src/test/resources/scenarios_examples/simple_step_iterations_fail_at_end.json
+++ b/engine/src/test/resources/scenarios_examples/simple_step_iterations_fail_at_end.json
@@ -6,7 +6,7 @@
                 "name": "<i> - Hello website on ${#env} with user ${#user}",
                 "type": "success",
                 "validations" : {
-                    "pouet_<i>_ok": "${#env == \"B\"}"
+                    "check_<i>_ok": "${#env == \"B\"}"
                 },
                 "strategy": {
                     "type": "for",

--- a/engine/src/test/resources/scenarios_examples/step_iteration_evaluated_dataset.json
+++ b/engine/src/test/resources/scenarios_examples/step_iteration_evaluated_dataset.json
@@ -20,10 +20,10 @@
                     "stringParam": "${#generatedID}"
                 },
                 "outputs": {
-                    "pouet_<idx>": "${\"/\" + #generatedID + \"/<idx>\"}"
+                    "check_<idx>": "${\"/\" + #generatedID + \"/<idx>\"}"
                 },
                 "validations": {
-                    "pouet_<idx>_ok": "${#pouet_<idx> == \"/\" + #generatedID + \"/<idx>\"}"
+                    "check_<idx>_ok": "${#check_<idx> == \"/\" + #generatedID + \"/<idx>\"}"
                 },
                 "strategy": {
                     "type": "for",

--- a/engine/src/test/resources/scenarios_examples/step_iteration_evaluated_dataset.json
+++ b/engine/src/test/resources/scenarios_examples/step_iteration_evaluated_dataset.json
@@ -1,0 +1,38 @@
+{
+    "dataset": {
+        "constants": {},
+        "datatable": [
+            {
+                "generatedID": "${#randomID()}"
+            },
+            {
+                "generatedID": "${#randomID()}"
+            }
+        ]
+    },
+    "scenario": {
+        "name": "Test iterations with local context evaluation",
+        "steps": [
+            {
+                "name": "<idx> - Use the ID ${#generatedID} generated in datable",
+                "type": "complex",
+                "inputs": {
+                    "stringParam": "${#generatedID}"
+                },
+                "outputs": {
+                    "pouet_<idx>": "${\"/\" + #generatedID + \"/<idx>\"}"
+                },
+                "validations": {
+                    "pouet_<idx>_ok": "${#pouet_<idx> == \"/\" + #generatedID + \"/<idx>\"}"
+                },
+                "strategy": {
+                    "type": "for",
+                    "parameters": {
+                        "index": "idx",
+                        "dataset": "${#dataset}"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/engine/src/test/resources/scenarios_examples/step_iterations_using_data_from_context.json
+++ b/engine/src/test/resources/scenarios_examples/step_iterations_using_data_from_context.json
@@ -28,11 +28,11 @@
                     "stringParam": "/${#env}/${#user}"
                 },
                 "outputs": {
-                    "pouet_<i>": "${\"/\" + #env + \"/\" + #user + \"/<i>\"}"
+                    "check_<i>": "${\"/\" + #env + \"/\" + #user + \"/<i>\"}"
                 },
                 "validations": {
                     "env_ok": "${#env == \"A\" || #env == \"B\"}",
-                    "pouet_<i>_ok": "${#pouet_<i> == \"/\" + #env + \"/\" + #user + \"/<i>\"}"
+                    "check_<i>_ok": "${#check_<i> == \"/\" + #env + \"/\" + #user + \"/<i>\"}"
                 },
                 "strategy": {
                     "type": "for",


### PR DESCRIPTION
#### Describe the changes you've made

Step iteration strategy evaluates each map data used for each iteration, using the scenario context before creating iterations.

Iterations cannot share any context from the scenario context since evaluation takes place before.
This is, IMHO, the desired behavior.
In any case, it might be possible to share context if evaluation takes place in the step.


Dataset constants are now evaluated with the scenario context, before the scenario is executed.
So it means only functions can be evaluated since execution has not started yet.
This is, IMHO, the desired behavior since constants should, by definition, be _constant_.

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
