### PR TITLE
Add closeable on TestEngine

### DIFF
--- a/engine/src/main/java/com/chutneytesting/ExecutionConfiguration.java
+++ b/engine/src/main/java/com/chutneytesting/ExecutionConfiguration.java
@@ -4,6 +4,14 @@ import static com.chutneytesting.tools.Streams.identity;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 
+import com.chutneytesting.action.domain.ActionTemplateLoader;
+import com.chutneytesting.action.domain.ActionTemplateLoaders;
+import com.chutneytesting.action.domain.ActionTemplateParserV2;
+import com.chutneytesting.action.domain.ActionTemplateRegistry;
+import com.chutneytesting.action.domain.DefaultActionTemplateRegistry;
+import com.chutneytesting.action.infra.DefaultActionTemplateLoader;
+import com.chutneytesting.action.spi.Action;
+import com.chutneytesting.action.spi.injectable.ActionsConfiguration;
 import com.chutneytesting.engine.api.execution.EmbeddedTestEngine;
 import com.chutneytesting.engine.api.execution.TestEngine;
 import com.chutneytesting.engine.domain.delegation.DelegationService;
@@ -18,20 +26,12 @@ import com.chutneytesting.engine.domain.execution.strategies.StepExecutionStrate
 import com.chutneytesting.engine.domain.execution.strategies.StepExecutionStrategy;
 import com.chutneytesting.engine.domain.report.Reporter;
 import com.chutneytesting.engine.infrastructure.delegation.HttpClient;
-import com.chutneytesting.action.domain.DefaultActionTemplateRegistry;
-import com.chutneytesting.action.domain.ActionTemplateLoader;
-import com.chutneytesting.action.domain.ActionTemplateLoaders;
-import com.chutneytesting.action.domain.ActionTemplateParserV2;
-import com.chutneytesting.action.domain.ActionTemplateRegistry;
-import com.chutneytesting.action.infra.DefaultActionTemplateLoader;
-import com.chutneytesting.action.spi.Action;
-import com.chutneytesting.action.spi.injectable.ActionsConfiguration;
 import com.chutneytesting.tools.ThrowingFunction;
 import com.chutneytesting.tools.loader.ExtensionLoaders;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -56,7 +56,7 @@ public class ExecutionConfiguration {
         this(5L, Executors.newFixedThreadPool(10), emptyMap(), null, null);
     }
 
-    public ExecutionConfiguration(Long reporterTTL, Executor actionExecutor, Map<String,String> actionsConfiguration, String user, String password) {
+    public ExecutionConfiguration(Long reporterTTL, ExecutorService actionExecutor, Map<String, String> actionsConfiguration, String user, String password) {
         this.reporterTTL = reporterTTL;
 
         ActionTemplateLoader actionTemplateLoaderV2 = createActionTemplateLoaderV2();
@@ -119,7 +119,7 @@ public class ExecutionConfiguration {
         return new Reporter(reporterTTL);
     }
 
-    private ExecutionEngine createExecutionEngine(Executor actionExecutor, String user, String password) {
+    private ExecutionEngine createExecutionEngine(ExecutorService actionExecutor, String user, String password) {
         return new DefaultExecutionEngine(
             new StepDataEvaluator(spelFunctions),
             new StepExecutionStrategies(stepExecutionStrategies),

--- a/engine/src/main/java/com/chutneytesting/engine/api/execution/EmbeddedTestEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/api/execution/EmbeddedTestEngine.java
@@ -59,4 +59,9 @@ public final class EmbeddedTestEngine implements TestEngine {
     public void stopExecution(Long executionId) {
         executionManager.stopExecution(executionId);
     }
+
+    @Override
+    public void close() {
+        engine.shutdown();
+    }
 }

--- a/engine/src/main/java/com/chutneytesting/engine/api/execution/HttpTestEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/api/execution/HttpTestEngine.java
@@ -55,4 +55,9 @@ public class HttpTestEngine implements TestEngine {
     public void stopExecution(Long executionId) {
         throw new IllegalArgumentException();
     }
+
+    @Override
+    public void close() throws Exception {
+        testEngine.close();
+    }
 }

--- a/engine/src/main/java/com/chutneytesting/engine/api/execution/TestEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/api/execution/TestEngine.java
@@ -2,6 +2,15 @@ package com.chutneytesting.engine.api.execution;
 
 import io.reactivex.rxjava3.core.Observable;
 
+/**
+ * Dont forget to use autocloseable resource :
+ * <pre>
+ *  try(testEngine) {
+ *    testEngine.execute(executionRequest)
+ *    ....
+ *  }
+ * </pre>
+ */
 public interface TestEngine extends AutoCloseable {
 
     StepExecutionReportDto execute(ExecutionRequestDto request);

--- a/engine/src/main/java/com/chutneytesting/engine/api/execution/TestEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/api/execution/TestEngine.java
@@ -2,7 +2,7 @@ package com.chutneytesting.engine.api.execution;
 
 import io.reactivex.rxjava3.core.Observable;
 
-public interface TestEngine {
+public interface TestEngine extends AutoCloseable {
 
     StepExecutionReportDto execute(ExecutionRequestDto request);
 

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/ExecutionEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/ExecutionEngine.java
@@ -6,4 +6,5 @@ public interface ExecutionEngine {
 
     Long execute(StepDefinition stepDefinition, Dataset dataset, ScenarioExecution execution);
 
+    void shutdown();
 }

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngine.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -38,7 +38,7 @@ public class DefaultExecutionEngine implements ExecutionEngine {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExecutionEngine.class);
 
-    private final Executor actionExecutor;
+    private final ExecutorService actionExecutor;
 
     private final StepDataEvaluator dataEvaluator;
     private final StepExecutionStrategies stepExecutionStrategies;
@@ -49,7 +49,7 @@ public class DefaultExecutionEngine implements ExecutionEngine {
                                   StepExecutionStrategies stepExecutionStrategies,
                                   DelegationService delegationService,
                                   Reporter reporter,
-                                  Executor actionExecutor) {
+                                  ExecutorService actionExecutor) {
         this.dataEvaluator = dataEvaluator;
         this.stepExecutionStrategies = stepExecutionStrategies != null ? stepExecutionStrategies : new StepExecutionStrategies();
         this.delegationService = delegationService;
@@ -94,6 +94,11 @@ public class DefaultExecutionEngine implements ExecutionEngine {
         });
 
         return execution.executionId;
+    }
+
+    @Override
+    public void shutdown() {
+        actionExecutor.shutdown();
     }
 
     private Map<String, ?> evaluateDatasetConstants(Dataset dataset, ScenarioContext scenarioContext) {

--- a/engine/src/test/java/com/chutneytesting/ExecutionConfigurationTest.java
+++ b/engine/src/test/java/com/chutneytesting/ExecutionConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.chutneytesting;
 
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.chutneytesting.action.domain.ActionTemplate;
@@ -18,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -119,6 +122,19 @@ public class ExecutionConfigurationTest {
         //T
         assertThat(result).hasFieldOrPropertyWithValue("status", StatusDto.FAILURE);
         assertThat(result.errors.get(0)).isEqualTo("Action [error] failed: Should be catch by fault barrier");
+    }
+
+    @Test
+    public void should_shutdown_threads_on_close() throws Exception {
+        //G
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        ExecutionConfiguration executionConfiguration = new ExecutionConfiguration(5L, executorService, emptyMap(), null, null);
+
+        //W
+        executionConfiguration.embeddedTestEngine().close();
+
+        //T
+        assertThat(executorService.isShutdown()).isTrue();
     }
 
     private StepDefinitionRequestDto createSucessStep() {

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -48,7 +48,7 @@ class DefaultExecutionEngineTest {
     private final StepExecutionStrategies stepExecutionStrategies = mock(StepExecutionStrategies.class);
     private final DelegationService delegationService = mock(DelegationService.class);
     private final String fakeEnvironment = "env";
-    private final Executor actionExecutor = Executors.newSingleThreadExecutor();
+    private final ExecutorService actionExecutor = Executors.newSingleThreadExecutor();
     public static final String tearDownRootNodeName = "TearDown";
     private static final String throwableToCatchMessage = "Should be caught by fault barrier";
     private final Dataset emptyDataset = new Dataset(emptyMap(), emptyList());

--- a/server/src/main/java/com/chutneytesting/ServerConfiguration.java
+++ b/server/src/main/java/com/chutneytesting/ServerConfiguration.java
@@ -87,7 +87,7 @@ public class ServerConfiguration {
      * For com.chutneytesting.ServerConfiguration#executionConfiguration()
      */
     @Bean
-    public TaskExecutor engineExecutor(@Value(ENGINE_EXECUTOR_POOL_SIZE_SPRING_VALUE) Integer threadForEngine) {
+    public ThreadPoolTaskExecutor engineExecutor(@Value(ENGINE_EXECUTOR_POOL_SIZE_SPRING_VALUE) Integer threadForEngine) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(threadForEngine);
         executor.setMaxPoolSize(threadForEngine);
@@ -114,14 +114,14 @@ public class ServerConfiguration {
     @Bean
     public ExecutionConfiguration executionConfiguration(
         @Value(ENGINE_REPORTER_PUBLISHER_TTL_SPRING_VALUE) Long reporterTTL,
-        @Qualifier("engineExecutor") TaskExecutor engineExecutor,
+        @Qualifier("engineExecutor") ThreadPoolTaskExecutor engineExecutor,
         @Value(TASK_SQL_NB_LOGGED_ROW_SPRING_VALUE) String nbLoggedRow,
         @Value(ENGINE_DELEGATION_USER_SPRING_VALUE) String delegateUser,
         @Value(ENGINE_DELEGATION_PASSWORD_SPRING_VALUE) String delegatePassword
     ) {
         Map<String, String> actionsConfiguration = new HashMap<>();
         actionsConfiguration.put(TASK_SQL_NB_LOGGED_ROW, nbLoggedRow);
-        return new ExecutionConfiguration(reporterTTL, engineExecutor, actionsConfiguration, delegateUser, delegatePassword);
+        return new ExecutionConfiguration(reporterTTL, engineExecutor.getThreadPoolExecutor(), actionsConfiguration, delegateUser, delegatePassword);
     }
 
     @Bean


### PR DESCRIPTION
#### Describe the changes you've made

TestEngine implements AutoCloseable in order to allow clients to turn off properly all threads from TestEngine.
Example of clients [Launcher](https://github.com/chutney-testing/chutney-kotlin-dsl/blob/95541586a93ba7b79638ec19d6534ac88ef1b8e6/dsl/src/main/kotlin/com/chutneytesting/kotlin/launcher/Launcher.kt)

#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
