### PR TITLE
feat: assert that no kafka message consumed

### DIFF
--- a/action-impl/src/main/java/com/chutneytesting/action/kafka/KafkaBasicConsumeAction.java
+++ b/action-impl/src/main/java/com/chutneytesting/action/kafka/KafkaBasicConsumeAction.java
@@ -135,8 +135,6 @@ public class KafkaBasicConsumeAction implements Action {
         try {
             logger.info("Consuming message from topic " + topic);
             messageListenerContainer.start();
-            if(nbMessages == 0)
-                TimeUnit.MILLISECONDS.sleep(Duration.parse(timeout).toMilliseconds());
             countDownLatch.await(Duration.parse(timeout).toMilliseconds(), TimeUnit.MILLISECONDS);
             if (consumedMessages.size() != nbMessages) {
                 logger.error("Unable to get the expected number of messages [" + nbMessages + "] during " + timeout + " from topic " + topic + ".");

--- a/action-impl/src/main/java/com/chutneytesting/action/kafka/KafkaBasicConsumeAction.java
+++ b/action-impl/src/main/java/com/chutneytesting/action/kafka/KafkaBasicConsumeAction.java
@@ -135,6 +135,8 @@ public class KafkaBasicConsumeAction implements Action {
         try {
             logger.info("Consuming message from topic " + topic);
             messageListenerContainer.start();
+            if(nbMessages == 0)
+                TimeUnit.MILLISECONDS.sleep(Duration.parse(timeout).toMilliseconds());
             countDownLatch.await(Duration.parse(timeout).toMilliseconds(), TimeUnit.MILLISECONDS);
             if (consumedMessages.size() != nbMessages) {
                 logger.error("Unable to get the expected number of messages [" + nbMessages + "] during " + timeout + " from topic " + topic + ".");
@@ -152,7 +154,7 @@ public class KafkaBasicConsumeAction implements Action {
 
     private MessageListener<String, String> createMessageListener() {
         return record -> {
-            if (countDownLatch.getCount() <= 0) {
+            if (countDownLatch.getCount() < 0) {
                 return;
             }
             final Map<String, Object> message = extractMessageFromRecord(record);

--- a/action-impl/src/main/java/com/chutneytesting/action/kafka/KafkaBasicConsumeAction.java
+++ b/action-impl/src/main/java/com/chutneytesting/action/kafka/KafkaBasicConsumeAction.java
@@ -107,7 +107,7 @@ public class KafkaBasicConsumeAction implements Action {
         this.contentType = ofNullable(contentType).map(ct -> defaultIfEmpty(ct, APPLICATION_JSON_VALUE)).map(MimeTypeUtils::parseMimeType).orElse(APPLICATION_JSON);
         this.timeout = defaultIfEmpty(timeout, "60 sec");
         this.target = target;
-        this.countDownLatch = new CountDownLatch(this.nbMessages);
+        this.countDownLatch = new CountDownLatch(this.nbMessages > 0 ? this.nbMessages : 1);
         this.group = group;
         this.logger = logger;
         this.properties = ofNullable(
@@ -154,7 +154,7 @@ public class KafkaBasicConsumeAction implements Action {
 
     private MessageListener<String, String> createMessageListener() {
         return record -> {
-            if (countDownLatch.getCount() < 0) {
+            if (countDownLatch.getCount() <= 0) {
                 return;
             }
             final Map<String, Object> message = extractMessageFromRecord(record);

--- a/action-impl/src/test/java/com/chutneytesting/action/kafka/KafkaBasicConsumeActionTest.java
+++ b/action-impl/src/test/java/com/chutneytesting/action/kafka/KafkaBasicConsumeActionTest.java
@@ -307,6 +307,23 @@ public class KafkaBasicConsumeActionTest {
         assertThat(logger.errors).isNotEmpty();
     }
 
+    @Test
+    public void should_return_exactly_nb_message_asked() {
+        // Given
+        Action sut = givenKafkaConsumeAction(1, null, null, TEXT_PLAIN_VALUE, "3 sec");
+        givenActionReceiveMessages(sut,
+            buildRecord(FIRST_OFFSET, "KEY", "test message"),
+            buildRecord(FIRST_OFFSET + 1, "KEY2", "test message2")
+        );
+
+        // When
+        ActionExecutionResult actionExecutionResult = sut.execute();
+
+        // Then
+        assertThat(actionExecutionResult.status).isEqualTo(Success);
+        assertActionOutputsSize(actionExecutionResult, 1);
+    }
+
     @ParameterizedTest
     @ValueSource(strings = APPLICATION_JSON_VALUE)
     @NullSource

--- a/action-impl/src/test/java/com/chutneytesting/action/kafka/KafkaBasicConsumeActionTest.java
+++ b/action-impl/src/test/java/com/chutneytesting/action/kafka/KafkaBasicConsumeActionTest.java
@@ -277,6 +277,36 @@ public class KafkaBasicConsumeActionTest {
         assertThat(logger.errors).isEmpty();
     }
 
+    @Test
+    public void should_not_find_any_message() {
+        // Given
+        Action sut = givenKafkaConsumeAction(0, null, null, TEXT_PLAIN_VALUE, "3 sec");
+
+        // When
+        ActionExecutionResult actionExecutionResult = sut.execute();
+
+        // Then
+        assertThat(actionExecutionResult.status).isEqualTo(Success);
+        assertActionOutputsSize(actionExecutionResult, 0);
+        assertThat(logger.errors).isEmpty();
+    }
+
+    @Test
+    public void should_not_find_any_message_failed() {
+        // Given
+        Action sut = givenKafkaConsumeAction(0, null, null, TEXT_PLAIN_VALUE, "3 sec");
+        givenActionReceiveMessages(sut,
+            buildRecord(FIRST_OFFSET, "KEY", "test message")
+        );
+
+        // When
+        ActionExecutionResult actionExecutionResult = sut.execute();
+
+        // Then
+        assertThat(actionExecutionResult.status).isEqualTo(Failure);
+        assertThat(logger.errors).isNotEmpty();
+    }
+
     @ParameterizedTest
     @ValueSource(strings = APPLICATION_JSON_VALUE)
     @NullSource


### PR DESCRIPTION

When `nb-messages == 0` in `kafka-basic-consume` chutney will wait the time we put in "timeout" and assert that no message queued in the chanel 


<!-- A good test plan should give instructions that someone else can easily follow.
How someone can test your code? -->


#### Checklist


- [ ] Refer to issue(s) the PR solves
- [x] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [x] All new and existing tests pass
- [x] No git conflict
