### PR TITLE
fix(engine): Iteration strategy accepts nested loop

### DIFF
--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -239,7 +240,7 @@ public class Step {
     }
 
     public List<Step> subSteps() {
-        return steps;
+        return new ArrayList<>(steps);
     }
 
     public StepExecutor executor() {

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/strategies/StepExecutionStrategy.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/strategies/StepExecutionStrategy.java
@@ -16,11 +16,12 @@
 
 package com.chutneytesting.engine.domain.execution.strategies;
 
+import static java.util.Collections.emptyMap;
+
 import com.chutneytesting.engine.domain.execution.ScenarioExecution;
 import com.chutneytesting.engine.domain.execution.engine.scenario.ScenarioContext;
 import com.chutneytesting.engine.domain.execution.engine.step.Step;
 import com.chutneytesting.engine.domain.execution.report.Status;
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -34,10 +35,10 @@ public interface StepExecutionStrategy {
     String getType();
 
     default Status execute(ScenarioExecution scenarioExecution,
-                   Step step,
-                   ScenarioContext scenarioContext,
-                   StepExecutionStrategies strategies) {
-        return execute(scenarioExecution, step, scenarioContext, Collections.emptyMap(), strategies);
+                           Step step,
+                           ScenarioContext scenarioContext,
+                           StepExecutionStrategies strategies) {
+        return execute(scenarioExecution, step, scenarioContext, emptyMap(), strategies);
     }
 
     Status execute(ScenarioExecution scenarioExecution,

--- a/engine/src/test/resources/scenarios_examples/step_nested_iterations_with_extended_dataset.json
+++ b/engine/src/test/resources/scenarios_examples/step_nested_iterations_with_extended_dataset.json
@@ -1,0 +1,52 @@
+{
+    "scenario": {
+        "name": "Test iterations",
+        "steps": [
+            {
+                "name": "<i> - Hello env ${#env} ",
+                "steps": [
+                    {
+                        "name": "<j> - Hello nested on ${#env} with user ${#user}",
+                        "type": "complex",
+                        "inputs": {
+                            "stringParam": "/${#env}/${#user}"
+                        },
+                        "outputs": {
+                            "check_<i>_<j>": "${\"/\" + #env + \"/\" + #user + \"/<j>\"}"
+                        },
+                        "validations" : {
+                            "check_<i>_<j>_ok": "${#check_<i>_<j> == \"/\" + #env + \"/\" + #user + \"/<j>\"}"
+                        },
+                        "strategy": {
+                            "type": "for",
+                            "parameters": {
+                                "index": "j",
+                                "dataset": [
+                                    {
+                                        "user": "userA"
+                                    },
+                                    {
+                                        "user": "userB"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "strategy": {
+                    "type": "for",
+                    "parameters": {
+                        "dataset": [
+                            {
+                                "env": "envX"
+                            },
+                            {
+                                "env": "envY"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/engine/src/test/resources/scenarios_examples/step_nested_iterations_with_overridden_dataset.json
+++ b/engine/src/test/resources/scenarios_examples/step_nested_iterations_with_overridden_dataset.json
@@ -1,0 +1,46 @@
+{
+    "scenario": {
+        "name": "Test iterations",
+        "steps": [
+            {
+                "name": "<i> - Hello env ${#env}",
+                "steps": [
+                    {
+                        "name": "<j> - I am nested for env ${#env}",
+                        "type": "complex",
+                        "outputs": {
+                            "environment_<i>.<j>": "${#env}"
+                        },
+                        "strategy": {
+                            "type": "for",
+                            "parameters": {
+                                "index": "j",
+                                "dataset": [
+                                    {
+                                        "env": "overriddenEnvX"
+                                    },
+                                    {
+                                        "env": "overriddenEnvY"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "strategy": {
+                    "type": "for",
+                    "parameters": {
+                        "dataset": [
+                            {
+                                "env": "envX"
+                            },
+                            {
+                                "env": "envY"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Describe the changes you've made

- Step returns a mutable copy of its substeps instead of its own reference. 
  - This allows for having nested iteration
- Local context is merged for each iteration
  - This allows to use a different dataset or override values in  the nested iterations

#### Describe if there is any unusual behaviour of your code <!-- Write `NA` if there isn't -->

- Evaluation of the step name with runtime values is not yet resolvable.
  - This was a special feature introduced only for iterations. But due to nesting iterations, it can't be done easily this way.
  - This is a limitation of the current Step impl. It could be fixed if the Step could evaluate its name itself, IMHO at the end of its execution
  - For now I choose to completely remove this "special" feature, since we should resolve it properly for all steps and not just iterations.
 
#### Checklist

<!-- To tick a checkbox, replace the whitespace by the letter 'x' such as: [x] -->

- [ ] Refer to issue(s) the PR solves
- [ ] New java code is covered by tests
- [ ] Add screenshots or gifs of the new behavior, if applicable.
- [ ] All new and existing tests pass
- [ ] No git conflict
